### PR TITLE
Remove tap highlight color on body for better UX

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -23,6 +23,7 @@ body {
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* App Container */


### PR DESCRIPTION
Added '-webkit-tap-highlight-color: transparent;' to the body selector to prevent the default tap highlight on touch devices, improving the user experience.