### PR TITLE
feat: add mark as read to reading modal

### DIFF
--- a/chrome/src/core/css/components.css
+++ b/chrome/src/core/css/components.css
@@ -76,6 +76,21 @@
   transform: scale(0.98);
 }
 
+.btn-outline-success {
+  border: 1px solid var(--success-bg);
+  background-color: transparent;
+  color: var(--success-bg);
+}
+
+.btn-outline-success:hover {
+  background-color: var(--success-bg);
+  color: var(--success-fg);
+}
+
+.btn-outline-success:active {
+  transform: scale(0.98);
+}
+
 .btn-ghost {
   background-color: transparent;
   color: var(--fg);
@@ -576,6 +591,28 @@
 }
 
 .btn-destructive:focus-visible {
+  outline: 2px solid var(--ring-color);
+  outline-offset: 2px;
+}
+
+.btn-success {
+  background-color: var(--success-bg);
+  color: var(--success-fg);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  border: 1px solid transparent;
+}
+
+.btn-success:hover {
+  background-color: var(--success-bg);
+  opacity: 0.9;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+}
+
+.btn-success:active {
+  transform: scale(0.98);
+}
+
+.btn-success:focus-visible {
   outline: 2px solid var(--ring-color);
   outline-offset: 2px;
 }

--- a/chrome/src/core/css/themes.css
+++ b/chrome/src/core/css/themes.css
@@ -18,6 +18,8 @@
   --accent-foreground: 222.2 47.4% 11.2%;
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 71% 45%;
+  --success-foreground: 210 40% 98%;
   --border: 214.3 31.8% 91.4%;
   --input: 214.3 31.8% 91.4%;
   --ring: 222.2 84% 4.9%;
@@ -42,6 +44,8 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 71% 35%;
+  --success-foreground: 210 40% 98%;
   --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
   --ring: 212.7 26.8% 83.9%;
@@ -65,6 +69,8 @@
   --accent-fg: hsl(var(--accent-foreground));
   --destructive-bg: hsl(var(--destructive));
   --destructive-fg: hsl(var(--destructive-foreground));
+  --success-bg: hsl(var(--success));
+  --success-fg: hsl(var(--success-foreground));
   --border-color: hsl(var(--border));
   --input-border: hsl(var(--input));
   --ring-color: hsl(var(--ring));

--- a/chrome/src/core/js/i18n.js
+++ b/chrome/src/core/js/i18n.js
@@ -179,7 +179,8 @@ const translations = {
       title: 'Quran Text',
       close: 'Close',
       loading: 'Loading...',
-      error: 'Error loading text'
+      error: 'Error loading text',
+      markAsRead: 'Mark as Read',
     },
     privacy: {
       title: 'Privacy Policy',
@@ -378,7 +379,8 @@ const translations = {
       title: 'نص القرآن',
       close: 'إغلاق',
       loading: 'جاري التحميل...',
-      error: 'خطأ في تحميل النص'
+      error: 'خطأ في تحميل النص',
+      markAsRead: 'تم القراءة',
     },
     privacy: {
       title: 'سياسة الخصوصية',

--- a/core/css/components.css
+++ b/core/css/components.css
@@ -76,6 +76,21 @@
   transform: scale(0.98);
 }
 
+.btn-outline-success {
+  border: 1px solid var(--success-bg);
+  background-color: transparent;
+  color: var(--success-bg);
+}
+
+.btn-outline-success:hover {
+  background-color: var(--success-bg);
+  color: var(--success-fg);
+}
+
+.btn-outline-success:active {
+  transform: scale(0.98);
+}
+
 .btn-ghost {
   background-color: transparent;
   color: var(--fg);
@@ -576,6 +591,28 @@
 }
 
 .btn-destructive:focus-visible {
+  outline: 2px solid var(--ring-color);
+  outline-offset: 2px;
+}
+
+.btn-success {
+  background-color: var(--success-bg);
+  color: var(--success-fg);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  border: 1px solid transparent;
+}
+
+.btn-success:hover {
+  background-color: var(--success-bg);
+  opacity: 0.9;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+}
+
+.btn-success:active {
+  transform: scale(0.98);
+}
+
+.btn-success:focus-visible {
   outline: 2px solid var(--ring-color);
   outline-offset: 2px;
 }

--- a/core/css/themes.css
+++ b/core/css/themes.css
@@ -18,6 +18,8 @@
   --accent-foreground: 222.2 47.4% 11.2%;
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 71% 45%;
+  --success-foreground: 210 40% 98%;
   --border: 214.3 31.8% 91.4%;
   --input: 214.3 31.8% 91.4%;
   --ring: 222.2 84% 4.9%;
@@ -42,6 +44,8 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 71% 35%;
+  --success-foreground: 210 40% 98%;
   --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
   --ring: 212.7 26.8% 83.9%;
@@ -65,6 +69,8 @@
   --accent-fg: hsl(var(--accent-foreground));
   --destructive-bg: hsl(var(--destructive));
   --destructive-fg: hsl(var(--destructive-foreground));
+  --success-bg: hsl(var(--success));
+  --success-fg: hsl(var(--success-foreground));
   --border-color: hsl(var(--border));
   --input-border: hsl(var(--input));
   --ring-color: hsl(var(--ring));

--- a/core/js/i18n.js
+++ b/core/js/i18n.js
@@ -179,7 +179,8 @@ const translations = {
       title: 'Quran Text',
       close: 'Close',
       loading: 'Loading...',
-      error: 'Error loading text'
+      error: 'Error loading text',
+      markAsRead: 'Mark as Read',
     },
     privacy: {
       title: 'Privacy Policy',
@@ -378,7 +379,8 @@ const translations = {
       title: 'نص القرآن',
       close: 'إغلاق',
       loading: 'جاري التحميل...',
-      error: 'خطأ في تحميل النص'
+      error: 'خطأ في تحميل النص',
+      markAsRead: 'تم القراءة',
     },
     privacy: {
       title: 'سياسة الخصوصية',

--- a/firefox/src/core/css/components.css
+++ b/firefox/src/core/css/components.css
@@ -76,6 +76,21 @@
   transform: scale(0.98);
 }
 
+.btn-outline-success {
+  border: 1px solid var(--success-bg);
+  background-color: transparent;
+  color: var(--success-bg);
+}
+
+.btn-outline-success:hover {
+  background-color: var(--success-bg);
+  color: var(--success-fg);
+}
+
+.btn-outline-success:active {
+  transform: scale(0.98);
+}
+
 .btn-ghost {
   background-color: transparent;
   color: var(--fg);
@@ -576,6 +591,28 @@
 }
 
 .btn-destructive:focus-visible {
+  outline: 2px solid var(--ring-color);
+  outline-offset: 2px;
+}
+
+.btn-success {
+  background-color: var(--success-bg);
+  color: var(--success-fg);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  border: 1px solid transparent;
+}
+
+.btn-success:hover {
+  background-color: var(--success-bg);
+  opacity: 0.9;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+}
+
+.btn-success:active {
+  transform: scale(0.98);
+}
+
+.btn-success:focus-visible {
   outline: 2px solid var(--ring-color);
   outline-offset: 2px;
 }

--- a/firefox/src/core/css/themes.css
+++ b/firefox/src/core/css/themes.css
@@ -18,6 +18,8 @@
   --accent-foreground: 222.2 47.4% 11.2%;
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 71% 45%;
+  --success-foreground: 210 40% 98%;
   --border: 214.3 31.8% 91.4%;
   --input: 214.3 31.8% 91.4%;
   --ring: 222.2 84% 4.9%;
@@ -42,6 +44,8 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 71% 35%;
+  --success-foreground: 210 40% 98%;
   --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
   --ring: 212.7 26.8% 83.9%;
@@ -65,6 +69,8 @@
   --accent-fg: hsl(var(--accent-foreground));
   --destructive-bg: hsl(var(--destructive));
   --destructive-fg: hsl(var(--destructive-foreground));
+  --success-bg: hsl(var(--success));
+  --success-fg: hsl(var(--success-foreground));
   --border-color: hsl(var(--border));
   --input-border: hsl(var(--input));
   --ring-color: hsl(var(--ring));

--- a/firefox/src/core/js/i18n.js
+++ b/firefox/src/core/js/i18n.js
@@ -179,7 +179,8 @@ const translations = {
       title: 'Quran Text',
       close: 'Close',
       loading: 'Loading...',
-      error: 'Error loading text'
+      error: 'Error loading text',
+      markAsRead: 'Mark as Read',
     },
     privacy: {
       title: 'Privacy Policy',
@@ -378,7 +379,8 @@ const translations = {
       title: 'نص القرآن',
       close: 'إغلاق',
       loading: 'جاري التحميل...',
-      error: 'خطأ في تحميل النص'
+      error: 'خطأ في تحميل النص',
+      markAsRead: 'تم القراءة',
     },
     privacy: {
       title: 'سياسة الخصوصية',

--- a/www/core/css/components.css
+++ b/www/core/css/components.css
@@ -76,6 +76,21 @@
   transform: scale(0.98);
 }
 
+.btn-outline-success {
+  border: 1px solid var(--success-bg);
+  background-color: transparent;
+  color: var(--success-bg);
+}
+
+.btn-outline-success:hover {
+  background-color: var(--success-bg);
+  color: var(--success-fg);
+}
+
+.btn-outline-success:active {
+  transform: scale(0.98);
+}
+
 .btn-ghost {
   background-color: transparent;
   color: var(--fg);
@@ -576,6 +591,28 @@
 }
 
 .btn-destructive:focus-visible {
+  outline: 2px solid var(--ring-color);
+  outline-offset: 2px;
+}
+
+.btn-success {
+  background-color: var(--success-bg);
+  color: var(--success-fg);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  border: 1px solid transparent;
+}
+
+.btn-success:hover {
+  background-color: var(--success-bg);
+  opacity: 0.9;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+}
+
+.btn-success:active {
+  transform: scale(0.98);
+}
+
+.btn-success:focus-visible {
   outline: 2px solid var(--ring-color);
   outline-offset: 2px;
 }

--- a/www/core/css/themes.css
+++ b/www/core/css/themes.css
@@ -18,6 +18,8 @@
   --accent-foreground: 222.2 47.4% 11.2%;
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 71% 45%;
+  --success-foreground: 210 40% 98%;
   --border: 214.3 31.8% 91.4%;
   --input: 214.3 31.8% 91.4%;
   --ring: 222.2 84% 4.9%;
@@ -42,6 +44,8 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 71% 35%;
+  --success-foreground: 210 40% 98%;
   --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
   --ring: 212.7 26.8% 83.9%;
@@ -65,6 +69,8 @@
   --accent-fg: hsl(var(--accent-foreground));
   --destructive-bg: hsl(var(--destructive));
   --destructive-fg: hsl(var(--destructive-foreground));
+  --success-bg: hsl(var(--success));
+  --success-fg: hsl(var(--success-foreground));
   --border-color: hsl(var(--border));
   --input-border: hsl(var(--input));
   --ring-color: hsl(var(--ring));

--- a/www/core/js/i18n.js
+++ b/www/core/js/i18n.js
@@ -179,7 +179,8 @@ const translations = {
       title: 'Quran Text',
       close: 'Close',
       loading: 'Loading...',
-      error: 'Error loading text'
+      error: 'Error loading text',
+      markAsRead: 'Mark as Read',
     },
     privacy: {
       title: 'Privacy Policy',
@@ -378,7 +379,8 @@ const translations = {
       title: 'نص القرآن',
       close: 'إغلاق',
       loading: 'جاري التحميل...',
-      error: 'خطأ في تحميل النص'
+      error: 'خطأ في تحميل النص',
+      markAsRead: 'تم القراءة',
     },
     privacy: {
       title: 'سياسة الخصوصية',


### PR DESCRIPTION
## Changes
- Added two button variants to `components.css` : `btn-success` and `btn-outline-success`.
- Added `markAsRead` i18n translations (English/Arabic).
- Updated `showReadingModal` method to accept task details.
- Added a footer to reading modal with a toggle button that switches between `btn-success` and `btn-outline-success` based on task completion status.
- Footer is only displayed when `textData` is available.

## Screenshots
| Unchecked | Checked |
|-----------|---------|
| <img width="300" alt="Unchecked state" src="https://github.com/user-attachments/assets/5b6d9cfd-6a9f-4834-9f03-4f11b5cf99d5" /> | <img width="300" alt="Checked state" src="https://github.com/user-attachments/assets/64529edd-2f34-4b7d-85b7-72cf9123068a" /> |

## Related Issue
Closes #6 
