### PR TITLE
feat: custom page unit size with fractional and ranged reader support

### DIFF
--- a/chrome/src/core/css/components.css
+++ b/chrome/src/core/css/components.css
@@ -676,6 +676,27 @@
   z-index: 1;
 }
 
+/* Unit size: horizontal scroll on small screens */
+.unit-size-options {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  flex-wrap: nowrap;
+}
+.unit-size-options .toggle-option {
+  flex: 0 1 auto;
+  min-width: 2.5rem;
+}
+
+/* Custom unit size input as sub-control (indent + subtle background) */
+.unit-size-custom-field {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  padding-inline-start: 1.25rem;
+  background-color: var(--muted-bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-color);
+}
+
 /* RTL Support for toggles */
 [dir="rtl"] .toggle-options {
   flex-direction: row-reverse;

--- a/chrome/src/core/js/dialog.js
+++ b/chrome/src/core/js/dialog.js
@@ -387,6 +387,31 @@ const Dialog = {
     startPageGroup.appendChild(startPageInput);
     form.appendChild(startPageGroup);
 
+    // Custom unit size (conditional, only for pages)
+    const customUnitSizeGroup = document.createElement('div');
+    customUnitSizeGroup.className = 'form-group';
+    customUnitSizeGroup.id = 'add-memorization-custom-unit-size-group';
+    customUnitSizeGroup.style.display = 'none';
+    const customUnitSizeLabel = document.createElement('label');
+    customUnitSizeLabel.setAttribute('for', 'add-memorization-custom-unit-size');
+    customUnitSizeLabel.textContent = i18n.t('setup.customUnitSize');
+    customUnitSizeGroup.appendChild(customUnitSizeLabel);
+    const customUnitSizeHint = document.createElement('p');
+    customUnitSizeHint.className = 'form-hint';
+    customUnitSizeHint.style.cssText = 'font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;';
+    customUnitSizeHint.textContent = i18n.t('setup.customUnitSizeDescription');
+    customUnitSizeGroup.appendChild(customUnitSizeHint);
+    const customUnitSizeInput = document.createElement('input');
+    customUnitSizeInput.type = 'number';
+    customUnitSizeInput.id = 'add-memorization-custom-unit-size';
+    customUnitSizeInput.className = 'input';
+    customUnitSizeInput.min = '0.5';
+    customUnitSizeInput.max = '10';
+    customUnitSizeInput.step = '0.5';
+    customUnitSizeInput.value = '1';
+    customUnitSizeGroup.appendChild(customUnitSizeInput);
+    form.appendChild(customUnitSizeGroup);
+
     // Total units
     const totalUnitsGroup = document.createElement('div');
     totalUnitsGroup.className = 'form-group';
@@ -431,11 +456,13 @@ const Dialog = {
         }
       }
 
-      // Show/hide start page field
+      // Show/hide start page field and custom unit size field
       if (selectedUnitType === 'page') {
         startPageGroup.style.display = 'block';
+        customUnitSizeGroup.style.display = 'block';
       } else {
         startPageGroup.style.display = 'none';
+        customUnitSizeGroup.style.display = 'none';
       }
     };
 
@@ -577,9 +604,10 @@ const Dialog = {
       const startDate = startDateInput.value;
       const progressionName = progressionNameInput.value || '';
       const startPage = (unitType === 'page') ? parseInt(startPageInput.value) || 1 : 1;
+      const unitSize = (unitType === 'page' && customUnitSizeInput) ? parseFloat(customUnitSizeInput.value) || 1 : null;
 
       overlay.remove();
-      if (onSubmit) onSubmit({ unitType, totalUnits, startDate, progressionName, startPage });
+      if (onSubmit) onSubmit({ unitType, totalUnits, startDate, progressionName, startPage, unit_size: unitSize });
     });
 
     dialog.appendChild(form);
@@ -876,6 +904,27 @@ const Dialog = {
     startPageGroup.appendChild(startPageInput);
     form.appendChild(startPageGroup);
 
+    var customUnitSizeGroup = document.createElement('div');
+    customUnitSizeGroup.className = 'form-group';
+    customUnitSizeGroup.style.display = 'none';
+    var customUnitSizeLabel = document.createElement('label');
+    customUnitSizeLabel.textContent = i18n.t('setup.customUnitSize');
+    customUnitSizeGroup.appendChild(customUnitSizeLabel);
+    var customUnitSizeHint = document.createElement('p');
+    customUnitSizeHint.className = 'form-hint';
+    customUnitSizeHint.style.cssText = 'font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;';
+    customUnitSizeHint.textContent = i18n.t('setup.customUnitSizeDescription');
+    customUnitSizeGroup.appendChild(customUnitSizeHint);
+    var customUnitSizeInput = document.createElement('input');
+    customUnitSizeInput.type = 'number';
+    customUnitSizeInput.className = 'input';
+    customUnitSizeInput.min = '0.5';
+    customUnitSizeInput.max = '10';
+    customUnitSizeInput.step = '0.5';
+    customUnitSizeInput.value = currentConfig.unit_size || 1;
+    customUnitSizeGroup.appendChild(customUnitSizeInput);
+    form.appendChild(customUnitSizeGroup);
+
     var updateFields = function () {
       var activeOpt = unitTypeToggle.querySelector('.active');
       var type = activeOpt ? activeOpt.getAttribute('data-value') : 'page';
@@ -890,6 +939,7 @@ const Dialog = {
       totalUnitsInput.max = maxUnits;
       if (parseInt(totalUnitsInput.value) > maxUnits) totalUnitsInput.value = maxUnits;
       startPageGroup.style.display = (type === 'page') ? 'block' : 'none';
+      customUnitSizeGroup.style.display = (type === 'page') ? 'block' : 'none';
     };
 
     updateFields();
@@ -923,6 +973,7 @@ const Dialog = {
       newData.progression_name = nameInput.value;
       newData.start_date = dateInput.value;
       newData.start_page = type === 'page' ? parseInt(startPageInput.value) : 1;
+      newData.unit_size = type === 'page' ? parseFloat(customUnitSizeInput.value) || 1 : null;
 
       overlay.remove();
       if (onSubmit) onSubmit(newData);

--- a/chrome/src/core/js/i18n.js
+++ b/chrome/src/core/js/i18n.js
@@ -22,7 +22,15 @@ const translations = {
       language: 'Language',
       startButton: 'Start Memorization',
       surahPreset: 'Big Surahs Preset (Optional)',
-      surahPresetNone: 'None'
+      surahPresetNone: 'None',
+      customUnitSize: 'Unit Size (pages)',
+      customUnitSizeDescription: 'How many pages per unit?',
+      unitSizeCustom: 'Custom',
+      unitSizeCustomValueLabel: 'Pages',
+      unitSizeCustomPlaceholder: 'e.g. 4',
+      unitsPerStep: 'Units per Step',
+      unitsPerStepDescription: 'Each task covers this many units',
+      totalUnitsDescription: 'Total number of units in this progression'
     },
     dashboard: {
       newMemorization: 'New Memorization',
@@ -222,7 +230,15 @@ const translations = {
       language: 'اللغة',
       startButton: 'بدء الحفظ',
       surahPreset: 'السور الكبيرة (اختياري)',
-      surahPresetNone: 'لا شيء'
+      surahPresetNone: 'لا شيء',
+      customUnitSize: 'حجم الوحدة (صفحات)',
+      customUnitSizeDescription: 'كم صفحة في كل وحدة؟',
+      unitSizeCustom: 'آخر',
+      unitSizeCustomValueLabel: 'صفحات',
+      unitSizeCustomPlaceholder: 'مثال 4',
+      unitsPerStep: 'الوحدات لكل خطوة',
+      unitsPerStepDescription: 'كل مهمة تغطي هذا العدد من الوحدات',
+      totalUnitsDescription: 'إجمالي عدد الوحدات في هذا التقدم'
     },
     dashboard: {
       newMemorization: 'الحفظ الجديد',

--- a/chrome/src/core/js/storage.js
+++ b/chrome/src/core/js/storage.js
@@ -28,6 +28,7 @@ const Storage = {
         morning_hour: config.morning_hour !== undefined ? config.morning_hour : DEFAULT_CONFIG.MORNING_HOUR,
         evening_hour: config.evening_hour !== undefined ? config.evening_hour : DEFAULT_CONFIG.EVENING_HOUR,
         start_page: config.start_page !== undefined ? config.start_page : 1,
+        unit_size: config.unit_type === 'page' && config.unit_size != null ? config.unit_size : null,
         updated_at: new Date().toISOString()
       };
       await StorageAdapter.set(STORAGE_KEYS.CONFIG, JSON.stringify(configData));

--- a/chrome/src/core/js/ui.js
+++ b/chrome/src/core/js/ui.js
@@ -268,12 +268,14 @@ const UI = {
     const progressionNameInput = DOMCache.getElementById('progression-name');
     const startPageInput = DOMCache.getElementById('start-page');
     const startPageGroup = DOMCache.getElementById('start-page-group');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
 
     if (config) {
       if (totalUnitsInput) totalUnitsInput.value = config.total_units || DEFAULT_CONFIG.TOTAL_UNITS;
       if (startDateInput) startDateInput.value = config.start_date || '';
       if (progressionNameInput) progressionNameInput.value = config.progression_name || '';
       if (startPageInput) startPageInput.value = config.start_page || 1;
+      if (customUnitSizeInput) customUnitSizeInput.value = config.unit_size || 1;
     } else {
       // Set default start date to today (using local date)
       if (startDateInput && !startDateInput.value) {
@@ -286,6 +288,9 @@ const UI = {
       if (startPageInput && !startPageInput.value) {
         startPageInput.value = 1;
       }
+      if (customUnitSizeInput && !customUnitSizeInput.value) {
+        customUnitSizeInput.value = 1;
+      }
     }
 
     // Update unit count label and start page visibility
@@ -293,6 +298,9 @@ const UI = {
 
     // Initialize toggle event listeners
     this.initSetupToggles();
+
+    // Sync unit-size toggle to current input value (preset vs Custom)
+    this.syncUnitSizeToggleFromInput();
 
     // Initialize number input buttons
     this.initNumberInput();
@@ -375,6 +383,8 @@ const UI = {
     const unitTypeToggle = DOMCache.getElementById('unit-type-toggle');
     const totalUnitsLabel = DOMCache.getElementById('total-units-label');
     const startPageGroup = DOMCache.getElementById('start-page-group');
+    const customUnitSizeGroup = DOMCache.getElementById('custom-unit-size-group');
+    const totalUnitsHint = DOMCache.getElementById('total-units-hint');
 
     if (!unitTypeToggle || !totalUnitsLabel) return;
 
@@ -404,6 +414,12 @@ const UI = {
     totalUnitsLabel.setAttribute('data-i18n', labelKey);
     totalUnitsLabel.textContent = i18n.t(labelKey);
 
+    // Update hint text
+    if (totalUnitsHint) {
+      totalUnitsHint.setAttribute('data-i18n', 'setup.totalUnitsDescription');
+      totalUnitsHint.textContent = i18n.t('setup.totalUnitsDescription');
+    }
+
     const totalUnitsInput = DOMCache.getElementById('total-units');
     if (totalUnitsInput) {
       totalUnitsInput.max = maxUnits;
@@ -412,12 +428,19 @@ const UI = {
       }
     }
 
-    // Show/hide start page field
+    // Show/hide start page field and custom unit size field
     if (startPageGroup) {
       if (selectedUnitType === 'page') {
         startPageGroup.style.display = 'block';
       } else {
         startPageGroup.style.display = 'none';
+      }
+    }
+    if (customUnitSizeGroup) {
+      if (selectedUnitType === 'page') {
+        customUnitSizeGroup.style.display = 'block';
+      } else {
+        customUnitSizeGroup.style.display = 'none';
       }
     }
   },
@@ -516,6 +539,57 @@ const UI = {
         });
       });
     }
+
+    // Unit size toggle (presets 0.5, 1, 1.5, 2, 2.5, 3, 3.5 + Custom)
+    const unitSizeToggle = DOMCache.getElementById('unit-size-toggle');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
+    const customUnitSizeInputWrap = DOMCache.getElementById('custom-unit-size-input-wrap');
+    if (unitSizeToggle && customUnitSizeInput) {
+      unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const value = btn.getAttribute('data-value');
+          unitSizeToggle.querySelectorAll('.toggle-option').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          if (value === 'custom') {
+            if (customUnitSizeInputWrap) customUnitSizeInputWrap.style.display = 'block';
+            customUnitSizeInput.focus();
+          } else {
+            if (customUnitSizeInputWrap) customUnitSizeInputWrap.style.display = 'none';
+            customUnitSizeInput.value = value;
+          }
+        });
+      });
+      if (customUnitSizeInput.addEventListener) {
+        customUnitSizeInput.addEventListener('change', () => {
+          this.syncUnitSizeToggleFromInput();
+        });
+      }
+    }
+  },
+
+  // Sync unit-size toggle UI from the hidden input value (preset active vs Custom + input visible)
+  syncUnitSizeToggleFromInput() {
+    const unitSizeToggle = DOMCache.getElementById('unit-size-toggle');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
+    const customUnitSizeInputWrap = DOMCache.getElementById('custom-unit-size-input-wrap');
+    if (!unitSizeToggle || !customUnitSizeInput) return;
+    const value = parseFloat(customUnitSizeInput.value) || 1;
+    const presets = ['0.5', '1', '1.5', '2', '2.5', '3', '3.5'];
+    const valueStr = value.toString();
+    const isPreset = presets.includes(valueStr);
+    unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
+      btn.classList.remove('active');
+      const dataVal = btn.getAttribute('data-value');
+      if (dataVal === 'custom') {
+        if (isPreset) return;
+        btn.classList.add('active');
+      } else if (parseFloat(dataVal) === value || (dataVal === valueStr)) {
+        btn.classList.add('active');
+      }
+    });
+    if (customUnitSizeInputWrap) {
+      customUnitSizeInputWrap.style.display = isPreset ? 'none' : 'block';
+    }
   },
 
   // Generate stable ID for an item based on unit type, number, and date
@@ -540,11 +614,18 @@ const UI = {
   async createOrUpdateItem(unitType, itemNumber, itemDateStr, config, allItems) {
     const stableId = this.generateItemId(unitType, itemNumber, itemDateStr);
     // Calculate actual unit number with start page offset for pages
+    // If unit_size is set, calculate fractional page numbers (e.g., unit_size=0.5 means half pages)
     let actualUnitNumber = itemNumber;
-    if (unitType === 'page' && config && config.start_page) {
-      actualUnitNumber = config.start_page + itemNumber - 1;
+    if (unitType === 'page' && config) {
+      const startPage = config.start_page || 1;
+      const unitSize = config.unit_size || 1;
+      // Calculate: start_page + (itemNumber - 1) * unit_size
+      // Example: start_page=1, unit_size=0.5, itemNumber=1 -> 1 + 0*0.5 = 1
+      //          start_page=1, unit_size=0.5, itemNumber=2 -> 1 + 1*0.5 = 1.5
+      //          start_page=1, unit_size=1.5, itemNumber=2 -> 1 + 1*1.5 = 2.5
+      actualUnitNumber = startPage + (itemNumber - 1) * unitSize;
     }
-    const contentRef = Algorithm.formatContentReference(unitType, actualUnitNumber);
+    const contentRef = Algorithm.formatContentReference(unitType, actualUnitNumber, config);
     const existingItem = this.findExistingItem(allItems, unitType, itemNumber, itemDateStr, stableId);
 
     if (!existingItem) {
@@ -841,7 +922,7 @@ const UI = {
         fragment.appendChild(empty);
       } else {
         uniqueTasks.forEach(({ item, priority, station, isCompleted }) => {
-          const taskCard = UIComponents.createTaskCard(item, station, priority, isCompleted, config.unit_type);
+          const taskCard = UIComponents.createTaskCard(item, station, priority, isCompleted, config.unit_type, config.unit_size, config);
           fragment.appendChild(taskCard);
         });
       }
@@ -1174,6 +1255,11 @@ const UI = {
           ? parseInt(startPageInput.value) || 1
           : 1;
 
+        const customUnitSizeInput = document.getElementById('custom-unit-size');
+        const unitSize = (unitType === 'page' && customUnitSizeInput)
+          ? parseFloat(customUnitSizeInput.value) || 1
+          : null;
+
         const config = {
           unit_type: unitType,
           total_units: parseInt(document.getElementById('total-units').value) || 30,
@@ -1183,7 +1269,8 @@ const UI = {
           theme: theme,
           morning_hour: DEFAULT_CONFIG.MORNING_HOUR,
           evening_hour: DEFAULT_CONFIG.EVENING_HOUR,
-          start_page: startPage
+          start_page: startPage,
+          unit_size: unitSize
         };
 
         await Storage.saveConfig(config);
@@ -1467,10 +1554,12 @@ const UI = {
         var stableId = this.generateItemId(newData.unit_type, itemNumber, itemDateStr);
 
         var actualUnitNumber = itemNumber;
-        if (newData.unit_type === 'page' && newData.start_page) {
-          actualUnitNumber = newData.start_page + itemNumber - 1;
+        if (newData.unit_type === 'page' && newData) {
+          var startPage = newData.start_page || 1;
+          var unitSize = newData.unit_size || 1;
+          actualUnitNumber = startPage + (itemNumber - 1) * unitSize;
         }
-        var contentRef = Algorithm.formatContentReference(newData.unit_type, actualUnitNumber);
+        var contentRef = Algorithm.formatContentReference(newData.unit_type, actualUnitNumber, newData);
 
         var newItem = {
           id: stableId,

--- a/core/css/components.css
+++ b/core/css/components.css
@@ -676,6 +676,27 @@
   z-index: 1;
 }
 
+/* Unit size: horizontal scroll on small screens */
+.unit-size-options {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  flex-wrap: nowrap;
+}
+.unit-size-options .toggle-option {
+  flex: 0 1 auto;
+  min-width: 2.5rem;
+}
+
+/* Custom unit size input as sub-control (indent + subtle background) */
+.unit-size-custom-field {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  padding-inline-start: 1.25rem;
+  background-color: var(--muted-bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-color);
+}
+
 /* RTL Support for toggles */
 [dir="rtl"] .toggle-options {
   flex-direction: row-reverse;

--- a/core/js/dialog.js
+++ b/core/js/dialog.js
@@ -387,6 +387,31 @@ const Dialog = {
     startPageGroup.appendChild(startPageInput);
     form.appendChild(startPageGroup);
 
+    // Custom unit size (conditional, only for pages)
+    const customUnitSizeGroup = document.createElement('div');
+    customUnitSizeGroup.className = 'form-group';
+    customUnitSizeGroup.id = 'add-memorization-custom-unit-size-group';
+    customUnitSizeGroup.style.display = 'none';
+    const customUnitSizeLabel = document.createElement('label');
+    customUnitSizeLabel.setAttribute('for', 'add-memorization-custom-unit-size');
+    customUnitSizeLabel.textContent = i18n.t('setup.customUnitSize');
+    customUnitSizeGroup.appendChild(customUnitSizeLabel);
+    const customUnitSizeHint = document.createElement('p');
+    customUnitSizeHint.className = 'form-hint';
+    customUnitSizeHint.style.cssText = 'font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;';
+    customUnitSizeHint.textContent = i18n.t('setup.customUnitSizeDescription');
+    customUnitSizeGroup.appendChild(customUnitSizeHint);
+    const customUnitSizeInput = document.createElement('input');
+    customUnitSizeInput.type = 'number';
+    customUnitSizeInput.id = 'add-memorization-custom-unit-size';
+    customUnitSizeInput.className = 'input';
+    customUnitSizeInput.min = '0.5';
+    customUnitSizeInput.max = '10';
+    customUnitSizeInput.step = '0.5';
+    customUnitSizeInput.value = '1';
+    customUnitSizeGroup.appendChild(customUnitSizeInput);
+    form.appendChild(customUnitSizeGroup);
+
     // Total units
     const totalUnitsGroup = document.createElement('div');
     totalUnitsGroup.className = 'form-group';
@@ -431,11 +456,13 @@ const Dialog = {
         }
       }
 
-      // Show/hide start page field
+      // Show/hide start page field and custom unit size field
       if (selectedUnitType === 'page') {
         startPageGroup.style.display = 'block';
+        customUnitSizeGroup.style.display = 'block';
       } else {
         startPageGroup.style.display = 'none';
+        customUnitSizeGroup.style.display = 'none';
       }
     };
 
@@ -577,9 +604,10 @@ const Dialog = {
       const startDate = startDateInput.value;
       const progressionName = progressionNameInput.value || '';
       const startPage = (unitType === 'page') ? parseInt(startPageInput.value) || 1 : 1;
+      const unitSize = (unitType === 'page' && customUnitSizeInput) ? parseFloat(customUnitSizeInput.value) || 1 : null;
 
       overlay.remove();
-      if (onSubmit) onSubmit({ unitType, totalUnits, startDate, progressionName, startPage });
+      if (onSubmit) onSubmit({ unitType, totalUnits, startDate, progressionName, startPage, unit_size: unitSize });
     });
 
     dialog.appendChild(form);
@@ -876,6 +904,27 @@ const Dialog = {
     startPageGroup.appendChild(startPageInput);
     form.appendChild(startPageGroup);
 
+    var customUnitSizeGroup = document.createElement('div');
+    customUnitSizeGroup.className = 'form-group';
+    customUnitSizeGroup.style.display = 'none';
+    var customUnitSizeLabel = document.createElement('label');
+    customUnitSizeLabel.textContent = i18n.t('setup.customUnitSize');
+    customUnitSizeGroup.appendChild(customUnitSizeLabel);
+    var customUnitSizeHint = document.createElement('p');
+    customUnitSizeHint.className = 'form-hint';
+    customUnitSizeHint.style.cssText = 'font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;';
+    customUnitSizeHint.textContent = i18n.t('setup.customUnitSizeDescription');
+    customUnitSizeGroup.appendChild(customUnitSizeHint);
+    var customUnitSizeInput = document.createElement('input');
+    customUnitSizeInput.type = 'number';
+    customUnitSizeInput.className = 'input';
+    customUnitSizeInput.min = '0.5';
+    customUnitSizeInput.max = '10';
+    customUnitSizeInput.step = '0.5';
+    customUnitSizeInput.value = currentConfig.unit_size || 1;
+    customUnitSizeGroup.appendChild(customUnitSizeInput);
+    form.appendChild(customUnitSizeGroup);
+
     var updateFields = function () {
       var activeOpt = unitTypeToggle.querySelector('.active');
       var type = activeOpt ? activeOpt.getAttribute('data-value') : 'page';
@@ -890,6 +939,7 @@ const Dialog = {
       totalUnitsInput.max = maxUnits;
       if (parseInt(totalUnitsInput.value) > maxUnits) totalUnitsInput.value = maxUnits;
       startPageGroup.style.display = (type === 'page') ? 'block' : 'none';
+      customUnitSizeGroup.style.display = (type === 'page') ? 'block' : 'none';
     };
 
     updateFields();
@@ -923,6 +973,7 @@ const Dialog = {
       newData.progression_name = nameInput.value;
       newData.start_date = dateInput.value;
       newData.start_page = type === 'page' ? parseInt(startPageInput.value) : 1;
+      newData.unit_size = type === 'page' ? parseFloat(customUnitSizeInput.value) || 1 : null;
 
       overlay.remove();
       if (onSubmit) onSubmit(newData);

--- a/core/js/i18n.js
+++ b/core/js/i18n.js
@@ -22,7 +22,15 @@ const translations = {
       language: 'Language',
       startButton: 'Start Memorization',
       surahPreset: 'Big Surahs Preset (Optional)',
-      surahPresetNone: 'None'
+      surahPresetNone: 'None',
+      customUnitSize: 'Unit Size (pages)',
+      customUnitSizeDescription: 'How many pages per unit?',
+      unitSizeCustom: 'Custom',
+      unitSizeCustomValueLabel: 'Pages',
+      unitSizeCustomPlaceholder: 'e.g. 4',
+      unitsPerStep: 'Units per Step',
+      unitsPerStepDescription: 'Each task covers this many units',
+      totalUnitsDescription: 'Total number of units in this progression'
     },
     dashboard: {
       newMemorization: 'New Memorization',
@@ -222,7 +230,15 @@ const translations = {
       language: 'اللغة',
       startButton: 'بدء الحفظ',
       surahPreset: 'السور الكبيرة (اختياري)',
-      surahPresetNone: 'لا شيء'
+      surahPresetNone: 'لا شيء',
+      customUnitSize: 'حجم الوحدة (صفحات)',
+      customUnitSizeDescription: 'كم صفحة في كل وحدة؟',
+      unitSizeCustom: 'آخر',
+      unitSizeCustomValueLabel: 'صفحات',
+      unitSizeCustomPlaceholder: 'مثال 4',
+      unitsPerStep: 'الوحدات لكل خطوة',
+      unitsPerStepDescription: 'كل مهمة تغطي هذا العدد من الوحدات',
+      totalUnitsDescription: 'إجمالي عدد الوحدات في هذا التقدم'
     },
     dashboard: {
       newMemorization: 'الحفظ الجديد',

--- a/core/js/storage.js
+++ b/core/js/storage.js
@@ -28,6 +28,7 @@ const Storage = {
         morning_hour: config.morning_hour !== undefined ? config.morning_hour : DEFAULT_CONFIG.MORNING_HOUR,
         evening_hour: config.evening_hour !== undefined ? config.evening_hour : DEFAULT_CONFIG.EVENING_HOUR,
         start_page: config.start_page !== undefined ? config.start_page : 1,
+        unit_size: config.unit_type === 'page' && config.unit_size != null ? config.unit_size : null,
         updated_at: new Date().toISOString()
       };
       await StorageAdapter.set(STORAGE_KEYS.CONFIG, JSON.stringify(configData));

--- a/core/js/ui.js
+++ b/core/js/ui.js
@@ -268,12 +268,14 @@ const UI = {
     const progressionNameInput = DOMCache.getElementById('progression-name');
     const startPageInput = DOMCache.getElementById('start-page');
     const startPageGroup = DOMCache.getElementById('start-page-group');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
 
     if (config) {
       if (totalUnitsInput) totalUnitsInput.value = config.total_units || DEFAULT_CONFIG.TOTAL_UNITS;
       if (startDateInput) startDateInput.value = config.start_date || '';
       if (progressionNameInput) progressionNameInput.value = config.progression_name || '';
       if (startPageInput) startPageInput.value = config.start_page || 1;
+      if (customUnitSizeInput) customUnitSizeInput.value = config.unit_size || 1;
     } else {
       // Set default start date to today (using local date)
       if (startDateInput && !startDateInput.value) {
@@ -286,6 +288,9 @@ const UI = {
       if (startPageInput && !startPageInput.value) {
         startPageInput.value = 1;
       }
+      if (customUnitSizeInput && !customUnitSizeInput.value) {
+        customUnitSizeInput.value = 1;
+      }
     }
 
     // Update unit count label and start page visibility
@@ -293,6 +298,9 @@ const UI = {
 
     // Initialize toggle event listeners
     this.initSetupToggles();
+
+    // Sync unit-size toggle to current input value (preset vs Custom)
+    this.syncUnitSizeToggleFromInput();
 
     // Initialize number input buttons
     this.initNumberInput();
@@ -375,6 +383,8 @@ const UI = {
     const unitTypeToggle = DOMCache.getElementById('unit-type-toggle');
     const totalUnitsLabel = DOMCache.getElementById('total-units-label');
     const startPageGroup = DOMCache.getElementById('start-page-group');
+    const customUnitSizeGroup = DOMCache.getElementById('custom-unit-size-group');
+    const totalUnitsHint = DOMCache.getElementById('total-units-hint');
 
     if (!unitTypeToggle || !totalUnitsLabel) return;
 
@@ -404,6 +414,12 @@ const UI = {
     totalUnitsLabel.setAttribute('data-i18n', labelKey);
     totalUnitsLabel.textContent = i18n.t(labelKey);
 
+    // Update hint text
+    if (totalUnitsHint) {
+      totalUnitsHint.setAttribute('data-i18n', 'setup.totalUnitsDescription');
+      totalUnitsHint.textContent = i18n.t('setup.totalUnitsDescription');
+    }
+
     const totalUnitsInput = DOMCache.getElementById('total-units');
     if (totalUnitsInput) {
       totalUnitsInput.max = maxUnits;
@@ -412,12 +428,19 @@ const UI = {
       }
     }
 
-    // Show/hide start page field
+    // Show/hide start page field and custom unit size field
     if (startPageGroup) {
       if (selectedUnitType === 'page') {
         startPageGroup.style.display = 'block';
       } else {
         startPageGroup.style.display = 'none';
+      }
+    }
+    if (customUnitSizeGroup) {
+      if (selectedUnitType === 'page') {
+        customUnitSizeGroup.style.display = 'block';
+      } else {
+        customUnitSizeGroup.style.display = 'none';
       }
     }
   },
@@ -516,6 +539,57 @@ const UI = {
         });
       });
     }
+
+    // Unit size toggle (presets 0.5, 1, 1.5, 2, 2.5, 3, 3.5 + Custom)
+    const unitSizeToggle = DOMCache.getElementById('unit-size-toggle');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
+    const customUnitSizeInputWrap = DOMCache.getElementById('custom-unit-size-input-wrap');
+    if (unitSizeToggle && customUnitSizeInput) {
+      unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const value = btn.getAttribute('data-value');
+          unitSizeToggle.querySelectorAll('.toggle-option').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          if (value === 'custom') {
+            if (customUnitSizeInputWrap) customUnitSizeInputWrap.style.display = 'block';
+            customUnitSizeInput.focus();
+          } else {
+            if (customUnitSizeInputWrap) customUnitSizeInputWrap.style.display = 'none';
+            customUnitSizeInput.value = value;
+          }
+        });
+      });
+      if (customUnitSizeInput.addEventListener) {
+        customUnitSizeInput.addEventListener('change', () => {
+          this.syncUnitSizeToggleFromInput();
+        });
+      }
+    }
+  },
+
+  // Sync unit-size toggle UI from the hidden input value (preset active vs Custom + input visible)
+  syncUnitSizeToggleFromInput() {
+    const unitSizeToggle = DOMCache.getElementById('unit-size-toggle');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
+    const customUnitSizeInputWrap = DOMCache.getElementById('custom-unit-size-input-wrap');
+    if (!unitSizeToggle || !customUnitSizeInput) return;
+    const value = parseFloat(customUnitSizeInput.value) || 1;
+    const presets = ['0.5', '1', '1.5', '2', '2.5', '3', '3.5'];
+    const valueStr = value.toString();
+    const isPreset = presets.includes(valueStr);
+    unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
+      btn.classList.remove('active');
+      const dataVal = btn.getAttribute('data-value');
+      if (dataVal === 'custom') {
+        if (isPreset) return;
+        btn.classList.add('active');
+      } else if (parseFloat(dataVal) === value || (dataVal === valueStr)) {
+        btn.classList.add('active');
+      }
+    });
+    if (customUnitSizeInputWrap) {
+      customUnitSizeInputWrap.style.display = isPreset ? 'none' : 'block';
+    }
   },
 
   // Generate stable ID for an item based on unit type, number, and date
@@ -540,11 +614,18 @@ const UI = {
   async createOrUpdateItem(unitType, itemNumber, itemDateStr, config, allItems) {
     const stableId = this.generateItemId(unitType, itemNumber, itemDateStr);
     // Calculate actual unit number with start page offset for pages
+    // If unit_size is set, calculate fractional page numbers (e.g., unit_size=0.5 means half pages)
     let actualUnitNumber = itemNumber;
-    if (unitType === 'page' && config && config.start_page) {
-      actualUnitNumber = config.start_page + itemNumber - 1;
+    if (unitType === 'page' && config) {
+      const startPage = config.start_page || 1;
+      const unitSize = config.unit_size || 1;
+      // Calculate: start_page + (itemNumber - 1) * unit_size
+      // Example: start_page=1, unit_size=0.5, itemNumber=1 -> 1 + 0*0.5 = 1
+      //          start_page=1, unit_size=0.5, itemNumber=2 -> 1 + 1*0.5 = 1.5
+      //          start_page=1, unit_size=1.5, itemNumber=2 -> 1 + 1*1.5 = 2.5
+      actualUnitNumber = startPage + (itemNumber - 1) * unitSize;
     }
-    const contentRef = Algorithm.formatContentReference(unitType, actualUnitNumber);
+    const contentRef = Algorithm.formatContentReference(unitType, actualUnitNumber, config);
     const existingItem = this.findExistingItem(allItems, unitType, itemNumber, itemDateStr, stableId);
 
     if (!existingItem) {
@@ -841,7 +922,7 @@ const UI = {
         fragment.appendChild(empty);
       } else {
         uniqueTasks.forEach(({ item, priority, station, isCompleted }) => {
-          const taskCard = UIComponents.createTaskCard(item, station, priority, isCompleted, config.unit_type);
+          const taskCard = UIComponents.createTaskCard(item, station, priority, isCompleted, config.unit_type, config.unit_size, config);
           fragment.appendChild(taskCard);
         });
       }
@@ -1174,6 +1255,11 @@ const UI = {
           ? parseInt(startPageInput.value) || 1
           : 1;
 
+        const customUnitSizeInput = document.getElementById('custom-unit-size');
+        const unitSize = (unitType === 'page' && customUnitSizeInput)
+          ? parseFloat(customUnitSizeInput.value) || 1
+          : null;
+
         const config = {
           unit_type: unitType,
           total_units: parseInt(document.getElementById('total-units').value) || 30,
@@ -1183,7 +1269,8 @@ const UI = {
           theme: theme,
           morning_hour: DEFAULT_CONFIG.MORNING_HOUR,
           evening_hour: DEFAULT_CONFIG.EVENING_HOUR,
-          start_page: startPage
+          start_page: startPage,
+          unit_size: unitSize
         };
 
         await Storage.saveConfig(config);
@@ -1467,10 +1554,12 @@ const UI = {
         var stableId = this.generateItemId(newData.unit_type, itemNumber, itemDateStr);
 
         var actualUnitNumber = itemNumber;
-        if (newData.unit_type === 'page' && newData.start_page) {
-          actualUnitNumber = newData.start_page + itemNumber - 1;
+        if (newData.unit_type === 'page' && newData) {
+          var startPage = newData.start_page || 1;
+          var unitSize = newData.unit_size || 1;
+          actualUnitNumber = startPage + (itemNumber - 1) * unitSize;
         }
-        var contentRef = Algorithm.formatContentReference(newData.unit_type, actualUnitNumber);
+        var contentRef = Algorithm.formatContentReference(newData.unit_type, actualUnitNumber, newData);
 
         var newItem = {
           id: stableId,

--- a/firefox/src/core/css/components.css
+++ b/firefox/src/core/css/components.css
@@ -676,6 +676,27 @@
   z-index: 1;
 }
 
+/* Unit size: horizontal scroll on small screens */
+.unit-size-options {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  flex-wrap: nowrap;
+}
+.unit-size-options .toggle-option {
+  flex: 0 1 auto;
+  min-width: 2.5rem;
+}
+
+/* Custom unit size input as sub-control (indent + subtle background) */
+.unit-size-custom-field {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  padding-inline-start: 1.25rem;
+  background-color: var(--muted-bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-color);
+}
+
 /* RTL Support for toggles */
 [dir="rtl"] .toggle-options {
   flex-direction: row-reverse;

--- a/firefox/src/core/js/dialog.js
+++ b/firefox/src/core/js/dialog.js
@@ -387,6 +387,31 @@ const Dialog = {
     startPageGroup.appendChild(startPageInput);
     form.appendChild(startPageGroup);
 
+    // Custom unit size (conditional, only for pages)
+    const customUnitSizeGroup = document.createElement('div');
+    customUnitSizeGroup.className = 'form-group';
+    customUnitSizeGroup.id = 'add-memorization-custom-unit-size-group';
+    customUnitSizeGroup.style.display = 'none';
+    const customUnitSizeLabel = document.createElement('label');
+    customUnitSizeLabel.setAttribute('for', 'add-memorization-custom-unit-size');
+    customUnitSizeLabel.textContent = i18n.t('setup.customUnitSize');
+    customUnitSizeGroup.appendChild(customUnitSizeLabel);
+    const customUnitSizeHint = document.createElement('p');
+    customUnitSizeHint.className = 'form-hint';
+    customUnitSizeHint.style.cssText = 'font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;';
+    customUnitSizeHint.textContent = i18n.t('setup.customUnitSizeDescription');
+    customUnitSizeGroup.appendChild(customUnitSizeHint);
+    const customUnitSizeInput = document.createElement('input');
+    customUnitSizeInput.type = 'number';
+    customUnitSizeInput.id = 'add-memorization-custom-unit-size';
+    customUnitSizeInput.className = 'input';
+    customUnitSizeInput.min = '0.5';
+    customUnitSizeInput.max = '10';
+    customUnitSizeInput.step = '0.5';
+    customUnitSizeInput.value = '1';
+    customUnitSizeGroup.appendChild(customUnitSizeInput);
+    form.appendChild(customUnitSizeGroup);
+
     // Total units
     const totalUnitsGroup = document.createElement('div');
     totalUnitsGroup.className = 'form-group';
@@ -431,11 +456,13 @@ const Dialog = {
         }
       }
 
-      // Show/hide start page field
+      // Show/hide start page field and custom unit size field
       if (selectedUnitType === 'page') {
         startPageGroup.style.display = 'block';
+        customUnitSizeGroup.style.display = 'block';
       } else {
         startPageGroup.style.display = 'none';
+        customUnitSizeGroup.style.display = 'none';
       }
     };
 
@@ -577,9 +604,10 @@ const Dialog = {
       const startDate = startDateInput.value;
       const progressionName = progressionNameInput.value || '';
       const startPage = (unitType === 'page') ? parseInt(startPageInput.value) || 1 : 1;
+      const unitSize = (unitType === 'page' && customUnitSizeInput) ? parseFloat(customUnitSizeInput.value) || 1 : null;
 
       overlay.remove();
-      if (onSubmit) onSubmit({ unitType, totalUnits, startDate, progressionName, startPage });
+      if (onSubmit) onSubmit({ unitType, totalUnits, startDate, progressionName, startPage, unit_size: unitSize });
     });
 
     dialog.appendChild(form);
@@ -876,6 +904,27 @@ const Dialog = {
     startPageGroup.appendChild(startPageInput);
     form.appendChild(startPageGroup);
 
+    var customUnitSizeGroup = document.createElement('div');
+    customUnitSizeGroup.className = 'form-group';
+    customUnitSizeGroup.style.display = 'none';
+    var customUnitSizeLabel = document.createElement('label');
+    customUnitSizeLabel.textContent = i18n.t('setup.customUnitSize');
+    customUnitSizeGroup.appendChild(customUnitSizeLabel);
+    var customUnitSizeHint = document.createElement('p');
+    customUnitSizeHint.className = 'form-hint';
+    customUnitSizeHint.style.cssText = 'font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;';
+    customUnitSizeHint.textContent = i18n.t('setup.customUnitSizeDescription');
+    customUnitSizeGroup.appendChild(customUnitSizeHint);
+    var customUnitSizeInput = document.createElement('input');
+    customUnitSizeInput.type = 'number';
+    customUnitSizeInput.className = 'input';
+    customUnitSizeInput.min = '0.5';
+    customUnitSizeInput.max = '10';
+    customUnitSizeInput.step = '0.5';
+    customUnitSizeInput.value = currentConfig.unit_size || 1;
+    customUnitSizeGroup.appendChild(customUnitSizeInput);
+    form.appendChild(customUnitSizeGroup);
+
     var updateFields = function () {
       var activeOpt = unitTypeToggle.querySelector('.active');
       var type = activeOpt ? activeOpt.getAttribute('data-value') : 'page';
@@ -890,6 +939,7 @@ const Dialog = {
       totalUnitsInput.max = maxUnits;
       if (parseInt(totalUnitsInput.value) > maxUnits) totalUnitsInput.value = maxUnits;
       startPageGroup.style.display = (type === 'page') ? 'block' : 'none';
+      customUnitSizeGroup.style.display = (type === 'page') ? 'block' : 'none';
     };
 
     updateFields();
@@ -923,6 +973,7 @@ const Dialog = {
       newData.progression_name = nameInput.value;
       newData.start_date = dateInput.value;
       newData.start_page = type === 'page' ? parseInt(startPageInput.value) : 1;
+      newData.unit_size = type === 'page' ? parseFloat(customUnitSizeInput.value) || 1 : null;
 
       overlay.remove();
       if (onSubmit) onSubmit(newData);

--- a/firefox/src/core/js/i18n.js
+++ b/firefox/src/core/js/i18n.js
@@ -22,7 +22,15 @@ const translations = {
       language: 'Language',
       startButton: 'Start Memorization',
       surahPreset: 'Big Surahs Preset (Optional)',
-      surahPresetNone: 'None'
+      surahPresetNone: 'None',
+      customUnitSize: 'Unit Size (pages)',
+      customUnitSizeDescription: 'How many pages per unit?',
+      unitSizeCustom: 'Custom',
+      unitSizeCustomValueLabel: 'Pages',
+      unitSizeCustomPlaceholder: 'e.g. 4',
+      unitsPerStep: 'Units per Step',
+      unitsPerStepDescription: 'Each task covers this many units',
+      totalUnitsDescription: 'Total number of units in this progression'
     },
     dashboard: {
       newMemorization: 'New Memorization',
@@ -222,7 +230,15 @@ const translations = {
       language: 'اللغة',
       startButton: 'بدء الحفظ',
       surahPreset: 'السور الكبيرة (اختياري)',
-      surahPresetNone: 'لا شيء'
+      surahPresetNone: 'لا شيء',
+      customUnitSize: 'حجم الوحدة (صفحات)',
+      customUnitSizeDescription: 'كم صفحة في كل وحدة؟',
+      unitSizeCustom: 'آخر',
+      unitSizeCustomValueLabel: 'صفحات',
+      unitSizeCustomPlaceholder: 'مثال 4',
+      unitsPerStep: 'الوحدات لكل خطوة',
+      unitsPerStepDescription: 'كل مهمة تغطي هذا العدد من الوحدات',
+      totalUnitsDescription: 'إجمالي عدد الوحدات في هذا التقدم'
     },
     dashboard: {
       newMemorization: 'الحفظ الجديد',

--- a/firefox/src/core/js/storage.js
+++ b/firefox/src/core/js/storage.js
@@ -28,6 +28,7 @@ const Storage = {
         morning_hour: config.morning_hour !== undefined ? config.morning_hour : DEFAULT_CONFIG.MORNING_HOUR,
         evening_hour: config.evening_hour !== undefined ? config.evening_hour : DEFAULT_CONFIG.EVENING_HOUR,
         start_page: config.start_page !== undefined ? config.start_page : 1,
+        unit_size: config.unit_type === 'page' && config.unit_size != null ? config.unit_size : null,
         updated_at: new Date().toISOString()
       };
       await StorageAdapter.set(STORAGE_KEYS.CONFIG, JSON.stringify(configData));

--- a/firefox/src/core/js/ui.js
+++ b/firefox/src/core/js/ui.js
@@ -268,12 +268,14 @@ const UI = {
     const progressionNameInput = DOMCache.getElementById('progression-name');
     const startPageInput = DOMCache.getElementById('start-page');
     const startPageGroup = DOMCache.getElementById('start-page-group');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
 
     if (config) {
       if (totalUnitsInput) totalUnitsInput.value = config.total_units || DEFAULT_CONFIG.TOTAL_UNITS;
       if (startDateInput) startDateInput.value = config.start_date || '';
       if (progressionNameInput) progressionNameInput.value = config.progression_name || '';
       if (startPageInput) startPageInput.value = config.start_page || 1;
+      if (customUnitSizeInput) customUnitSizeInput.value = config.unit_size || 1;
     } else {
       // Set default start date to today (using local date)
       if (startDateInput && !startDateInput.value) {
@@ -286,6 +288,9 @@ const UI = {
       if (startPageInput && !startPageInput.value) {
         startPageInput.value = 1;
       }
+      if (customUnitSizeInput && !customUnitSizeInput.value) {
+        customUnitSizeInput.value = 1;
+      }
     }
 
     // Update unit count label and start page visibility
@@ -293,6 +298,9 @@ const UI = {
 
     // Initialize toggle event listeners
     this.initSetupToggles();
+
+    // Sync unit-size toggle to current input value (preset vs Custom)
+    this.syncUnitSizeToggleFromInput();
 
     // Initialize number input buttons
     this.initNumberInput();
@@ -375,6 +383,8 @@ const UI = {
     const unitTypeToggle = DOMCache.getElementById('unit-type-toggle');
     const totalUnitsLabel = DOMCache.getElementById('total-units-label');
     const startPageGroup = DOMCache.getElementById('start-page-group');
+    const customUnitSizeGroup = DOMCache.getElementById('custom-unit-size-group');
+    const totalUnitsHint = DOMCache.getElementById('total-units-hint');
 
     if (!unitTypeToggle || !totalUnitsLabel) return;
 
@@ -404,6 +414,12 @@ const UI = {
     totalUnitsLabel.setAttribute('data-i18n', labelKey);
     totalUnitsLabel.textContent = i18n.t(labelKey);
 
+    // Update hint text
+    if (totalUnitsHint) {
+      totalUnitsHint.setAttribute('data-i18n', 'setup.totalUnitsDescription');
+      totalUnitsHint.textContent = i18n.t('setup.totalUnitsDescription');
+    }
+
     const totalUnitsInput = DOMCache.getElementById('total-units');
     if (totalUnitsInput) {
       totalUnitsInput.max = maxUnits;
@@ -412,12 +428,19 @@ const UI = {
       }
     }
 
-    // Show/hide start page field
+    // Show/hide start page field and custom unit size field
     if (startPageGroup) {
       if (selectedUnitType === 'page') {
         startPageGroup.style.display = 'block';
       } else {
         startPageGroup.style.display = 'none';
+      }
+    }
+    if (customUnitSizeGroup) {
+      if (selectedUnitType === 'page') {
+        customUnitSizeGroup.style.display = 'block';
+      } else {
+        customUnitSizeGroup.style.display = 'none';
       }
     }
   },
@@ -516,6 +539,57 @@ const UI = {
         });
       });
     }
+
+    // Unit size toggle (presets 0.5, 1, 1.5, 2, 2.5, 3, 3.5 + Custom)
+    const unitSizeToggle = DOMCache.getElementById('unit-size-toggle');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
+    const customUnitSizeInputWrap = DOMCache.getElementById('custom-unit-size-input-wrap');
+    if (unitSizeToggle && customUnitSizeInput) {
+      unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const value = btn.getAttribute('data-value');
+          unitSizeToggle.querySelectorAll('.toggle-option').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          if (value === 'custom') {
+            if (customUnitSizeInputWrap) customUnitSizeInputWrap.style.display = 'block';
+            customUnitSizeInput.focus();
+          } else {
+            if (customUnitSizeInputWrap) customUnitSizeInputWrap.style.display = 'none';
+            customUnitSizeInput.value = value;
+          }
+        });
+      });
+      if (customUnitSizeInput.addEventListener) {
+        customUnitSizeInput.addEventListener('change', () => {
+          this.syncUnitSizeToggleFromInput();
+        });
+      }
+    }
+  },
+
+  // Sync unit-size toggle UI from the hidden input value (preset active vs Custom + input visible)
+  syncUnitSizeToggleFromInput() {
+    const unitSizeToggle = DOMCache.getElementById('unit-size-toggle');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
+    const customUnitSizeInputWrap = DOMCache.getElementById('custom-unit-size-input-wrap');
+    if (!unitSizeToggle || !customUnitSizeInput) return;
+    const value = parseFloat(customUnitSizeInput.value) || 1;
+    const presets = ['0.5', '1', '1.5', '2', '2.5', '3', '3.5'];
+    const valueStr = value.toString();
+    const isPreset = presets.includes(valueStr);
+    unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
+      btn.classList.remove('active');
+      const dataVal = btn.getAttribute('data-value');
+      if (dataVal === 'custom') {
+        if (isPreset) return;
+        btn.classList.add('active');
+      } else if (parseFloat(dataVal) === value || (dataVal === valueStr)) {
+        btn.classList.add('active');
+      }
+    });
+    if (customUnitSizeInputWrap) {
+      customUnitSizeInputWrap.style.display = isPreset ? 'none' : 'block';
+    }
   },
 
   // Generate stable ID for an item based on unit type, number, and date
@@ -540,11 +614,18 @@ const UI = {
   async createOrUpdateItem(unitType, itemNumber, itemDateStr, config, allItems) {
     const stableId = this.generateItemId(unitType, itemNumber, itemDateStr);
     // Calculate actual unit number with start page offset for pages
+    // If unit_size is set, calculate fractional page numbers (e.g., unit_size=0.5 means half pages)
     let actualUnitNumber = itemNumber;
-    if (unitType === 'page' && config && config.start_page) {
-      actualUnitNumber = config.start_page + itemNumber - 1;
+    if (unitType === 'page' && config) {
+      const startPage = config.start_page || 1;
+      const unitSize = config.unit_size || 1;
+      // Calculate: start_page + (itemNumber - 1) * unit_size
+      // Example: start_page=1, unit_size=0.5, itemNumber=1 -> 1 + 0*0.5 = 1
+      //          start_page=1, unit_size=0.5, itemNumber=2 -> 1 + 1*0.5 = 1.5
+      //          start_page=1, unit_size=1.5, itemNumber=2 -> 1 + 1*1.5 = 2.5
+      actualUnitNumber = startPage + (itemNumber - 1) * unitSize;
     }
-    const contentRef = Algorithm.formatContentReference(unitType, actualUnitNumber);
+    const contentRef = Algorithm.formatContentReference(unitType, actualUnitNumber, config);
     const existingItem = this.findExistingItem(allItems, unitType, itemNumber, itemDateStr, stableId);
 
     if (!existingItem) {
@@ -841,7 +922,7 @@ const UI = {
         fragment.appendChild(empty);
       } else {
         uniqueTasks.forEach(({ item, priority, station, isCompleted }) => {
-          const taskCard = UIComponents.createTaskCard(item, station, priority, isCompleted, config.unit_type);
+          const taskCard = UIComponents.createTaskCard(item, station, priority, isCompleted, config.unit_type, config.unit_size, config);
           fragment.appendChild(taskCard);
         });
       }
@@ -1174,6 +1255,11 @@ const UI = {
           ? parseInt(startPageInput.value) || 1
           : 1;
 
+        const customUnitSizeInput = document.getElementById('custom-unit-size');
+        const unitSize = (unitType === 'page' && customUnitSizeInput)
+          ? parseFloat(customUnitSizeInput.value) || 1
+          : null;
+
         const config = {
           unit_type: unitType,
           total_units: parseInt(document.getElementById('total-units').value) || 30,
@@ -1183,7 +1269,8 @@ const UI = {
           theme: theme,
           morning_hour: DEFAULT_CONFIG.MORNING_HOUR,
           evening_hour: DEFAULT_CONFIG.EVENING_HOUR,
-          start_page: startPage
+          start_page: startPage,
+          unit_size: unitSize
         };
 
         await Storage.saveConfig(config);
@@ -1467,10 +1554,12 @@ const UI = {
         var stableId = this.generateItemId(newData.unit_type, itemNumber, itemDateStr);
 
         var actualUnitNumber = itemNumber;
-        if (newData.unit_type === 'page' && newData.start_page) {
-          actualUnitNumber = newData.start_page + itemNumber - 1;
+        if (newData.unit_type === 'page' && newData) {
+          var startPage = newData.start_page || 1;
+          var unitSize = newData.unit_size || 1;
+          actualUnitNumber = startPage + (itemNumber - 1) * unitSize;
         }
-        var contentRef = Algorithm.formatContentReference(newData.unit_type, actualUnitNumber);
+        var contentRef = Algorithm.formatContentReference(newData.unit_type, actualUnitNumber, newData);
 
         var newItem = {
           id: stableId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monthlyquran",
-  "version": "1.1.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monthlyquran",
-      "version": "1.1.1",
+      "version": "1.5.2",
       "license": "ISC",
       "dependencies": {
         "@capacitor/android": "^8.0.0",

--- a/www/core/css/components.css
+++ b/www/core/css/components.css
@@ -676,6 +676,27 @@
   z-index: 1;
 }
 
+/* Unit size: horizontal scroll on small screens */
+.unit-size-options {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  flex-wrap: nowrap;
+}
+.unit-size-options .toggle-option {
+  flex: 0 1 auto;
+  min-width: 2.5rem;
+}
+
+/* Custom unit size input as sub-control (indent + subtle background) */
+.unit-size-custom-field {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  padding-inline-start: 1.25rem;
+  background-color: var(--muted-bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-color);
+}
+
 /* RTL Support for toggles */
 [dir="rtl"] .toggle-options {
   flex-direction: row-reverse;

--- a/www/core/js/dialog.js
+++ b/www/core/js/dialog.js
@@ -387,6 +387,31 @@ const Dialog = {
     startPageGroup.appendChild(startPageInput);
     form.appendChild(startPageGroup);
 
+    // Custom unit size (conditional, only for pages)
+    const customUnitSizeGroup = document.createElement('div');
+    customUnitSizeGroup.className = 'form-group';
+    customUnitSizeGroup.id = 'add-memorization-custom-unit-size-group';
+    customUnitSizeGroup.style.display = 'none';
+    const customUnitSizeLabel = document.createElement('label');
+    customUnitSizeLabel.setAttribute('for', 'add-memorization-custom-unit-size');
+    customUnitSizeLabel.textContent = i18n.t('setup.customUnitSize');
+    customUnitSizeGroup.appendChild(customUnitSizeLabel);
+    const customUnitSizeHint = document.createElement('p');
+    customUnitSizeHint.className = 'form-hint';
+    customUnitSizeHint.style.cssText = 'font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;';
+    customUnitSizeHint.textContent = i18n.t('setup.customUnitSizeDescription');
+    customUnitSizeGroup.appendChild(customUnitSizeHint);
+    const customUnitSizeInput = document.createElement('input');
+    customUnitSizeInput.type = 'number';
+    customUnitSizeInput.id = 'add-memorization-custom-unit-size';
+    customUnitSizeInput.className = 'input';
+    customUnitSizeInput.min = '0.5';
+    customUnitSizeInput.max = '10';
+    customUnitSizeInput.step = '0.5';
+    customUnitSizeInput.value = '1';
+    customUnitSizeGroup.appendChild(customUnitSizeInput);
+    form.appendChild(customUnitSizeGroup);
+
     // Total units
     const totalUnitsGroup = document.createElement('div');
     totalUnitsGroup.className = 'form-group';
@@ -431,11 +456,13 @@ const Dialog = {
         }
       }
 
-      // Show/hide start page field
+      // Show/hide start page field and custom unit size field
       if (selectedUnitType === 'page') {
         startPageGroup.style.display = 'block';
+        customUnitSizeGroup.style.display = 'block';
       } else {
         startPageGroup.style.display = 'none';
+        customUnitSizeGroup.style.display = 'none';
       }
     };
 
@@ -577,9 +604,10 @@ const Dialog = {
       const startDate = startDateInput.value;
       const progressionName = progressionNameInput.value || '';
       const startPage = (unitType === 'page') ? parseInt(startPageInput.value) || 1 : 1;
+      const unitSize = (unitType === 'page' && customUnitSizeInput) ? parseFloat(customUnitSizeInput.value) || 1 : null;
 
       overlay.remove();
-      if (onSubmit) onSubmit({ unitType, totalUnits, startDate, progressionName, startPage });
+      if (onSubmit) onSubmit({ unitType, totalUnits, startDate, progressionName, startPage, unit_size: unitSize });
     });
 
     dialog.appendChild(form);
@@ -876,6 +904,27 @@ const Dialog = {
     startPageGroup.appendChild(startPageInput);
     form.appendChild(startPageGroup);
 
+    var customUnitSizeGroup = document.createElement('div');
+    customUnitSizeGroup.className = 'form-group';
+    customUnitSizeGroup.style.display = 'none';
+    var customUnitSizeLabel = document.createElement('label');
+    customUnitSizeLabel.textContent = i18n.t('setup.customUnitSize');
+    customUnitSizeGroup.appendChild(customUnitSizeLabel);
+    var customUnitSizeHint = document.createElement('p');
+    customUnitSizeHint.className = 'form-hint';
+    customUnitSizeHint.style.cssText = 'font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;';
+    customUnitSizeHint.textContent = i18n.t('setup.customUnitSizeDescription');
+    customUnitSizeGroup.appendChild(customUnitSizeHint);
+    var customUnitSizeInput = document.createElement('input');
+    customUnitSizeInput.type = 'number';
+    customUnitSizeInput.className = 'input';
+    customUnitSizeInput.min = '0.5';
+    customUnitSizeInput.max = '10';
+    customUnitSizeInput.step = '0.5';
+    customUnitSizeInput.value = currentConfig.unit_size || 1;
+    customUnitSizeGroup.appendChild(customUnitSizeInput);
+    form.appendChild(customUnitSizeGroup);
+
     var updateFields = function () {
       var activeOpt = unitTypeToggle.querySelector('.active');
       var type = activeOpt ? activeOpt.getAttribute('data-value') : 'page';
@@ -890,6 +939,7 @@ const Dialog = {
       totalUnitsInput.max = maxUnits;
       if (parseInt(totalUnitsInput.value) > maxUnits) totalUnitsInput.value = maxUnits;
       startPageGroup.style.display = (type === 'page') ? 'block' : 'none';
+      customUnitSizeGroup.style.display = (type === 'page') ? 'block' : 'none';
     };
 
     updateFields();
@@ -923,6 +973,7 @@ const Dialog = {
       newData.progression_name = nameInput.value;
       newData.start_date = dateInput.value;
       newData.start_page = type === 'page' ? parseInt(startPageInput.value) : 1;
+      newData.unit_size = type === 'page' ? parseFloat(customUnitSizeInput.value) || 1 : null;
 
       overlay.remove();
       if (onSubmit) onSubmit(newData);

--- a/www/core/js/i18n.js
+++ b/www/core/js/i18n.js
@@ -22,7 +22,15 @@ const translations = {
       language: 'Language',
       startButton: 'Start Memorization',
       surahPreset: 'Big Surahs Preset (Optional)',
-      surahPresetNone: 'None'
+      surahPresetNone: 'None',
+      customUnitSize: 'Unit Size (pages)',
+      customUnitSizeDescription: 'How many pages per unit?',
+      unitSizeCustom: 'Custom',
+      unitSizeCustomValueLabel: 'Pages',
+      unitSizeCustomPlaceholder: 'e.g. 4',
+      unitsPerStep: 'Units per Step',
+      unitsPerStepDescription: 'Each task covers this many units',
+      totalUnitsDescription: 'Total number of units in this progression'
     },
     dashboard: {
       newMemorization: 'New Memorization',
@@ -222,7 +230,15 @@ const translations = {
       language: 'اللغة',
       startButton: 'بدء الحفظ',
       surahPreset: 'السور الكبيرة (اختياري)',
-      surahPresetNone: 'لا شيء'
+      surahPresetNone: 'لا شيء',
+      customUnitSize: 'حجم الوحدة (صفحات)',
+      customUnitSizeDescription: 'كم صفحة في كل وحدة؟',
+      unitSizeCustom: 'آخر',
+      unitSizeCustomValueLabel: 'صفحات',
+      unitSizeCustomPlaceholder: 'مثال 4',
+      unitsPerStep: 'الوحدات لكل خطوة',
+      unitsPerStepDescription: 'كل مهمة تغطي هذا العدد من الوحدات',
+      totalUnitsDescription: 'إجمالي عدد الوحدات في هذا التقدم'
     },
     dashboard: {
       newMemorization: 'الحفظ الجديد',

--- a/www/core/js/storage.js
+++ b/www/core/js/storage.js
@@ -28,6 +28,7 @@ const Storage = {
         morning_hour: config.morning_hour !== undefined ? config.morning_hour : DEFAULT_CONFIG.MORNING_HOUR,
         evening_hour: config.evening_hour !== undefined ? config.evening_hour : DEFAULT_CONFIG.EVENING_HOUR,
         start_page: config.start_page !== undefined ? config.start_page : 1,
+        unit_size: config.unit_type === 'page' && config.unit_size != null ? config.unit_size : null,
         updated_at: new Date().toISOString()
       };
       await StorageAdapter.set(STORAGE_KEYS.CONFIG, JSON.stringify(configData));

--- a/www/core/js/ui.js
+++ b/www/core/js/ui.js
@@ -268,12 +268,14 @@ const UI = {
     const progressionNameInput = DOMCache.getElementById('progression-name');
     const startPageInput = DOMCache.getElementById('start-page');
     const startPageGroup = DOMCache.getElementById('start-page-group');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
 
     if (config) {
       if (totalUnitsInput) totalUnitsInput.value = config.total_units || DEFAULT_CONFIG.TOTAL_UNITS;
       if (startDateInput) startDateInput.value = config.start_date || '';
       if (progressionNameInput) progressionNameInput.value = config.progression_name || '';
       if (startPageInput) startPageInput.value = config.start_page || 1;
+      if (customUnitSizeInput) customUnitSizeInput.value = config.unit_size || 1;
     } else {
       // Set default start date to today (using local date)
       if (startDateInput && !startDateInput.value) {
@@ -286,6 +288,9 @@ const UI = {
       if (startPageInput && !startPageInput.value) {
         startPageInput.value = 1;
       }
+      if (customUnitSizeInput && !customUnitSizeInput.value) {
+        customUnitSizeInput.value = 1;
+      }
     }
 
     // Update unit count label and start page visibility
@@ -293,6 +298,9 @@ const UI = {
 
     // Initialize toggle event listeners
     this.initSetupToggles();
+
+    // Sync unit-size toggle to current input value (preset vs Custom)
+    this.syncUnitSizeToggleFromInput();
 
     // Initialize number input buttons
     this.initNumberInput();
@@ -375,6 +383,8 @@ const UI = {
     const unitTypeToggle = DOMCache.getElementById('unit-type-toggle');
     const totalUnitsLabel = DOMCache.getElementById('total-units-label');
     const startPageGroup = DOMCache.getElementById('start-page-group');
+    const customUnitSizeGroup = DOMCache.getElementById('custom-unit-size-group');
+    const totalUnitsHint = DOMCache.getElementById('total-units-hint');
 
     if (!unitTypeToggle || !totalUnitsLabel) return;
 
@@ -404,6 +414,12 @@ const UI = {
     totalUnitsLabel.setAttribute('data-i18n', labelKey);
     totalUnitsLabel.textContent = i18n.t(labelKey);
 
+    // Update hint text
+    if (totalUnitsHint) {
+      totalUnitsHint.setAttribute('data-i18n', 'setup.totalUnitsDescription');
+      totalUnitsHint.textContent = i18n.t('setup.totalUnitsDescription');
+    }
+
     const totalUnitsInput = DOMCache.getElementById('total-units');
     if (totalUnitsInput) {
       totalUnitsInput.max = maxUnits;
@@ -412,12 +428,19 @@ const UI = {
       }
     }
 
-    // Show/hide start page field
+    // Show/hide start page field and custom unit size field
     if (startPageGroup) {
       if (selectedUnitType === 'page') {
         startPageGroup.style.display = 'block';
       } else {
         startPageGroup.style.display = 'none';
+      }
+    }
+    if (customUnitSizeGroup) {
+      if (selectedUnitType === 'page') {
+        customUnitSizeGroup.style.display = 'block';
+      } else {
+        customUnitSizeGroup.style.display = 'none';
       }
     }
   },
@@ -516,6 +539,57 @@ const UI = {
         });
       });
     }
+
+    // Unit size toggle (presets 0.5, 1, 1.5, 2, 2.5, 3, 3.5 + Custom)
+    const unitSizeToggle = DOMCache.getElementById('unit-size-toggle');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
+    const customUnitSizeInputWrap = DOMCache.getElementById('custom-unit-size-input-wrap');
+    if (unitSizeToggle && customUnitSizeInput) {
+      unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const value = btn.getAttribute('data-value');
+          unitSizeToggle.querySelectorAll('.toggle-option').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          if (value === 'custom') {
+            if (customUnitSizeInputWrap) customUnitSizeInputWrap.style.display = 'block';
+            customUnitSizeInput.focus();
+          } else {
+            if (customUnitSizeInputWrap) customUnitSizeInputWrap.style.display = 'none';
+            customUnitSizeInput.value = value;
+          }
+        });
+      });
+      if (customUnitSizeInput.addEventListener) {
+        customUnitSizeInput.addEventListener('change', () => {
+          this.syncUnitSizeToggleFromInput();
+        });
+      }
+    }
+  },
+
+  // Sync unit-size toggle UI from the hidden input value (preset active vs Custom + input visible)
+  syncUnitSizeToggleFromInput() {
+    const unitSizeToggle = DOMCache.getElementById('unit-size-toggle');
+    const customUnitSizeInput = DOMCache.getElementById('custom-unit-size');
+    const customUnitSizeInputWrap = DOMCache.getElementById('custom-unit-size-input-wrap');
+    if (!unitSizeToggle || !customUnitSizeInput) return;
+    const value = parseFloat(customUnitSizeInput.value) || 1;
+    const presets = ['0.5', '1', '1.5', '2', '2.5', '3', '3.5'];
+    const valueStr = value.toString();
+    const isPreset = presets.includes(valueStr);
+    unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
+      btn.classList.remove('active');
+      const dataVal = btn.getAttribute('data-value');
+      if (dataVal === 'custom') {
+        if (isPreset) return;
+        btn.classList.add('active');
+      } else if (parseFloat(dataVal) === value || (dataVal === valueStr)) {
+        btn.classList.add('active');
+      }
+    });
+    if (customUnitSizeInputWrap) {
+      customUnitSizeInputWrap.style.display = isPreset ? 'none' : 'block';
+    }
   },
 
   // Generate stable ID for an item based on unit type, number, and date
@@ -540,11 +614,18 @@ const UI = {
   async createOrUpdateItem(unitType, itemNumber, itemDateStr, config, allItems) {
     const stableId = this.generateItemId(unitType, itemNumber, itemDateStr);
     // Calculate actual unit number with start page offset for pages
+    // If unit_size is set, calculate fractional page numbers (e.g., unit_size=0.5 means half pages)
     let actualUnitNumber = itemNumber;
-    if (unitType === 'page' && config && config.start_page) {
-      actualUnitNumber = config.start_page + itemNumber - 1;
+    if (unitType === 'page' && config) {
+      const startPage = config.start_page || 1;
+      const unitSize = config.unit_size || 1;
+      // Calculate: start_page + (itemNumber - 1) * unit_size
+      // Example: start_page=1, unit_size=0.5, itemNumber=1 -> 1 + 0*0.5 = 1
+      //          start_page=1, unit_size=0.5, itemNumber=2 -> 1 + 1*0.5 = 1.5
+      //          start_page=1, unit_size=1.5, itemNumber=2 -> 1 + 1*1.5 = 2.5
+      actualUnitNumber = startPage + (itemNumber - 1) * unitSize;
     }
-    const contentRef = Algorithm.formatContentReference(unitType, actualUnitNumber);
+    const contentRef = Algorithm.formatContentReference(unitType, actualUnitNumber, config);
     const existingItem = this.findExistingItem(allItems, unitType, itemNumber, itemDateStr, stableId);
 
     if (!existingItem) {
@@ -841,7 +922,7 @@ const UI = {
         fragment.appendChild(empty);
       } else {
         uniqueTasks.forEach(({ item, priority, station, isCompleted }) => {
-          const taskCard = UIComponents.createTaskCard(item, station, priority, isCompleted, config.unit_type);
+          const taskCard = UIComponents.createTaskCard(item, station, priority, isCompleted, config.unit_type, config.unit_size, config);
           fragment.appendChild(taskCard);
         });
       }
@@ -1174,6 +1255,11 @@ const UI = {
           ? parseInt(startPageInput.value) || 1
           : 1;
 
+        const customUnitSizeInput = document.getElementById('custom-unit-size');
+        const unitSize = (unitType === 'page' && customUnitSizeInput)
+          ? parseFloat(customUnitSizeInput.value) || 1
+          : null;
+
         const config = {
           unit_type: unitType,
           total_units: parseInt(document.getElementById('total-units').value) || 30,
@@ -1183,7 +1269,8 @@ const UI = {
           theme: theme,
           morning_hour: DEFAULT_CONFIG.MORNING_HOUR,
           evening_hour: DEFAULT_CONFIG.EVENING_HOUR,
-          start_page: startPage
+          start_page: startPage,
+          unit_size: unitSize
         };
 
         await Storage.saveConfig(config);
@@ -1467,10 +1554,12 @@ const UI = {
         var stableId = this.generateItemId(newData.unit_type, itemNumber, itemDateStr);
 
         var actualUnitNumber = itemNumber;
-        if (newData.unit_type === 'page' && newData.start_page) {
-          actualUnitNumber = newData.start_page + itemNumber - 1;
+        if (newData.unit_type === 'page' && newData) {
+          var startPage = newData.start_page || 1;
+          var unitSize = newData.unit_size || 1;
+          actualUnitNumber = startPage + (itemNumber - 1) * unitSize;
         }
-        var contentRef = Algorithm.formatContentReference(newData.unit_type, actualUnitNumber);
+        var contentRef = Algorithm.formatContentReference(newData.unit_type, actualUnitNumber, newData);
 
         var newItem = {
           id: stableId,

--- a/www/index.html
+++ b/www/index.html
@@ -86,9 +86,33 @@
                                 <input type="number" id="start-page" class="input" min="1" max="604" value="1">
                             </div>
 
+                            <div class="form-group" id="custom-unit-size-group" style="display: none;" role="group" aria-labelledby="unit-size-pages-label">
+                                <label id="unit-size-pages-label" data-i18n="setup.customUnitSize">Unit Size (pages)</label>
+                                <p class="form-hint" style="font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;" data-i18n="setup.customUnitSizeDescription">How many pages per unit?</p>
+                                <div class="setup-toggles">
+                                    <div class="setup-toggle-group">
+                                        <div class="toggle-options unit-size-options" id="unit-size-toggle" role="group" aria-label="Unit Size">
+                                            <button type="button" class="toggle-option" data-value="0.5">0.5</button>
+                                            <button type="button" class="toggle-option" data-value="1">1</button>
+                                            <button type="button" class="toggle-option" data-value="1.5">1.5</button>
+                                            <button type="button" class="toggle-option" data-value="2">2</button>
+                                            <button type="button" class="toggle-option" data-value="2.5">2.5</button>
+                                            <button type="button" class="toggle-option" data-value="3">3</button>
+                                            <button type="button" class="toggle-option" data-value="3.5">3.5</button>
+                                            <button type="button" class="toggle-option" data-value="custom" data-i18n="setup.unitSizeCustom">Custom</button>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div id="custom-unit-size-input-wrap" class="form-group unit-size-custom-field" style="display: none;">
+                                    <label for="custom-unit-size" data-i18n="setup.unitSizeCustomValueLabel">Pages</label>
+                                    <input type="number" id="custom-unit-size" class="input" min="0.5" max="10" step="0.5" value="1" placeholder="e.g. 4" data-i18n="setup.unitSizeCustomPlaceholder">
+                                </div>
+                            </div>
+
                             <div class="form-group">
                                 <label for="total-units" id="total-units-label" data-i18n="setup.totalUnits">Total
                                     Units</label>
+                                <p class="form-hint" id="total-units-hint" style="font-size: 0.875rem; color: var(--muted-fg); margin: 0.25rem 0 0.75rem 0;" data-i18n="setup.totalUnitsDescription">Total number of units in this progression</p>
                                 <div class="number-input-group">
                                     <button type="button" class="number-input-btn" id="total-units-decrease"
                                         aria-label="Decrease">


### PR DESCRIPTION
What
Adds support for custom page-based unit sizes (e.g. 0.5, 1.5, 3.5 pages per unit).

Why
Users need finer control over memorization progressions when using pages.

How
- New “Unit Size (pages)” input in setup and edit flows
- Clear distinction between unit size and total units
- Algorithm maps units to page ranges using unit_size
- Reader supports fractional and multi-page ranges
- unit_size persisted in config

Closes #3
