### PR TITLE
feat: Add native haptic feedback for mobile experience

### DIFF
--- a/www/core/js/calendar.js
+++ b/www/core/js/calendar.js
@@ -228,6 +228,7 @@ const Calendar = {
 
       // Click handler
       dayEl.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.selection();
         this.selectDate(date);
       });
 
@@ -354,6 +355,7 @@ const Calendar = {
     if (!filterSelect.dataset.listenerAttached) {
       filterSelect.dataset.listenerAttached = 'true';
       filterSelect.addEventListener('change', (e) => {
+        if (typeof HapticsService !== 'undefined') HapticsService.light();
         this.selectedProgression = e.target.value;
         this.render();
       });

--- a/www/core/js/ui.js
+++ b/www/core/js/ui.js
@@ -321,6 +321,7 @@ const UI = {
 
     if (decreaseBtn && input) {
       decreaseBtn.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.light();
         const currentValue = parseInt(input.value) || DEFAULT_CONFIG.TOTAL_UNITS;
         const newValue = Math.max(1, currentValue - 1);
         input.value = newValue;
@@ -330,6 +331,7 @@ const UI = {
 
     if (increaseBtn && input) {
       increaseBtn.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.light();
         const currentValue = parseInt(input.value) || DEFAULT_CONFIG.TOTAL_UNITS;
         const newValue = currentValue + 1;
         input.value = newValue;
@@ -458,6 +460,8 @@ const UI = {
       const selectedValue = e.target.value;
       if (!selectedValue) return;
 
+      if (typeof HapticsService !== 'undefined') HapticsService.selection();
+
       const option = e.target.querySelector(`option[value="${selectedValue}"]`);
       if (!option || !option.dataset.surahData) return;
 
@@ -503,6 +507,7 @@ const UI = {
     if (unitTypeToggle) {
       unitTypeToggle.querySelectorAll('.toggle-option').forEach(btn => {
         btn.addEventListener('click', () => {
+          if (typeof HapticsService !== 'undefined') HapticsService.selection();
           const value = btn.getAttribute('data-value');
           unitTypeToggle.querySelectorAll('.toggle-option').forEach(b => b.classList.remove('active'));
           btn.classList.add('active');
@@ -517,6 +522,7 @@ const UI = {
     if (languageToggle) {
       languageToggle.querySelectorAll('.toggle-option').forEach(btn => {
         btn.addEventListener('click', () => {
+          if (typeof HapticsService !== 'undefined') HapticsService.selection();
           const value = btn.getAttribute('data-value');
           languageToggle.querySelectorAll('.toggle-option').forEach(b => b.classList.remove('active'));
           btn.classList.add('active');
@@ -534,6 +540,7 @@ const UI = {
     if (themeToggle) {
       themeToggle.querySelectorAll('.toggle-option').forEach(btn => {
         btn.addEventListener('click', () => {
+          if (typeof HapticsService !== 'undefined') HapticsService.selection();
           const value = btn.getAttribute('data-value');
           themeToggle.querySelectorAll('.toggle-option').forEach(b => b.classList.remove('active'));
           btn.classList.add('active');
@@ -551,6 +558,7 @@ const UI = {
     if (unitSizeToggle && customUnitSizeInput) {
       unitSizeToggle.querySelectorAll('.toggle-option').forEach(btn => {
         btn.addEventListener('click', () => {
+          if (typeof HapticsService !== 'undefined') HapticsService.selection();
           const value = btn.getAttribute('data-value');
           unitSizeToggle.querySelectorAll('.toggle-option').forEach(b => b.classList.remove('active'));
           btn.classList.add('active');
@@ -1541,6 +1549,8 @@ const UI = {
       setupForm.addEventListener('submit', async (e) => {
         e.preventDefault();
 
+        if (typeof HapticsService !== 'undefined') HapticsService.success();
+
         // Get values from toggles
         const unitTypeToggle = DOMCache.getElementById('unit-type-toggle');
         const languageToggle = DOMCache.getElementById('setup-language-toggle');
@@ -1630,6 +1640,7 @@ const UI = {
     const privacyBtn = DOMCache.getElementById('settings-privacy-btn');
     if (privacyBtn) {
       privacyBtn.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.selection();
         this.showView('privacy-view');
       });
     }
@@ -1638,6 +1649,7 @@ const UI = {
     const privacyBackBtn = DOMCache.getElementById('privacy-back-btn');
     if (privacyBackBtn) {
       privacyBackBtn.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.selection();
         this.showView('settings-view');
       });
     }
@@ -1646,6 +1658,7 @@ const UI = {
     const exportBtn = DOMCache.getElementById('settings-export-btn');
     if (exportBtn) {
       exportBtn.addEventListener('click', async () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.selection();
         const data = await Storage.exportData();
         if (!data) return;
 
@@ -1693,6 +1706,7 @@ const UI = {
     const importBtn = DOMCache.getElementById('settings-import-btn');
     if (importBtn) {
       importBtn.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.selection();
         const input = document.createElement('input');
         input.type = 'file';
         input.accept = 'application/json';
@@ -1727,6 +1741,7 @@ const UI = {
     const resetBtn = DOMCache.getElementById('settings-reset-btn');
     if (resetBtn) {
       resetBtn.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.warning();
         Dialog.showResetConfirm(async () => {
           await Storage.clearAll();
           await Theme.init();
@@ -1742,6 +1757,7 @@ const UI = {
     const progressAddBtn = DOMCache.getElementById('progress-add-btn');
     if (progressAddBtn) {
       progressAddBtn.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.selection();
         Dialog.showAddMemorizationModal(async (data) => {
           const { unitType, totalUnits, startDate, progressionName, startPage } = data;
           const config = await Storage.getConfig();
@@ -1773,6 +1789,7 @@ const UI = {
     const themeToggles = document.querySelectorAll('#theme-toggle, #theme-toggle-progress, #theme-toggle-calendar, #theme-toggle-settings, #theme-toggle-credits');
     themeToggles.forEach(toggle => {
       toggle.addEventListener('click', () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.light();
         Theme.toggle();
       });
     });
@@ -1781,6 +1798,7 @@ const UI = {
     const languageToggles = document.querySelectorAll('#language-toggle, #language-toggle-progress, #language-toggle-calendar, #language-toggle-settings, #language-toggle-credits');
     languageToggles.forEach(toggle => {
       toggle.addEventListener('click', async () => {
+        if (typeof HapticsService !== 'undefined') HapticsService.light();
         const config = await Storage.getConfig();
         if (config) {
           const currentLang = i18n.getLanguage();

--- a/www/core/js/utils/haptics.js
+++ b/www/core/js/utils/haptics.js
@@ -1,9 +1,13 @@
 // core/js/utils/haptics.js
 const HapticsService = {
   isEnabled: true,
+  hasNativeHaptics: false,
+  hasWebVibrate: false,
 
   async init(config) {
     this.isEnabled = config?.enable_haptics !== false; // Default true if not explicitly false
+    this.hasNativeHaptics = !!(window.Capacitor && window.Capacitor.isNative);
+    this.hasWebVibrate = !!navigator.vibrate;
   },
 
   updateConfig(isEnabled) {
@@ -11,40 +15,99 @@ const HapticsService = {
   },
 
   async isAvailable() {
-    return this.isEnabled && 
-           window.Capacitor && 
+    if (!this.isEnabled) return false;
+
+    // Check for Capacitor native haptics
+    const hasCapacitorHaptics = window.Capacitor && 
            window.Capacitor.isNative && 
            window.Capacitor.Plugins &&
            window.Capacitor.Plugins.Haptics;
+
+    // Check for Web Vibration API (for PWA/browser)
+    const hasVibrationApi = !!navigator.vibrate;
+
+    return hasCapacitorHaptics || hasVibrationApi;
   },
 
+  // Web Vibration API patterns (in milliseconds)
+  PATTERNS: {
+    SUCCESS: [50, 50, 50],
+    WARNING: [100, 50, 100],
+    ERROR: [200, 100, 200],
+    LIGHT: 10,
+    MEDIUM: 25,
+    HEAVY: 40,
+    SELECTION: 15
+  },
+
+  // Native Capacitor haptics
   async success() {
-    if (await this.isAvailable()) {
+    if (!this.isEnabled) return;
+
+    if (this.hasNativeHaptics && window.Capacitor.Plugins.Haptics) {
       await window.Capacitor.Plugins.Haptics.notification({ type: 'SUCCESS' }).catch(() => {});
+    } else if (this.hasWebVibrate && navigator.vibrate) {
+      navigator.vibrate(this.PATTERNS.SUCCESS);
     }
   },
 
   async warning() {
-    if (await this.isAvailable()) {
+    if (!this.isEnabled) return;
+
+    if (this.hasNativeHaptics && window.Capacitor.Plugins.Haptics) {
       await window.Capacitor.Plugins.Haptics.notification({ type: 'WARNING' }).catch(() => {});
+    } else if (this.hasWebVibrate && navigator.vibrate) {
+      navigator.vibrate(this.PATTERNS.WARNING);
+    }
+  },
+
+  async error() {
+    if (!this.isEnabled) return;
+
+    if (this.hasNativeHaptics && window.Capacitor.Plugins.Haptics) {
+      await window.Capacitor.Plugins.Haptics.notification({ type: 'ERROR' }).catch(() => {});
+    } else if (this.hasWebVibrate && navigator.vibrate) {
+      navigator.vibrate(this.PATTERNS.ERROR);
     }
   },
 
   async selection() {
-    if (await this.isAvailable()) {
+    if (!this.isEnabled) return;
+
+    if (this.hasNativeHaptics && window.Capacitor.Plugins.Haptics) {
       await window.Capacitor.Plugins.Haptics.selectionStart().catch(() => {});
+    } else if (this.hasWebVibrate && navigator.vibrate) {
+      navigator.vibrate(this.PATTERNS.SELECTION);
     }
   },
 
   async light() {
-    if (await this.isAvailable()) {
+    if (!this.isEnabled) return;
+
+    if (this.hasNativeHaptics && window.Capacitor.Plugins.Haptics) {
       await window.Capacitor.Plugins.Haptics.impact({ style: 'LIGHT' }).catch(() => {});
+    } else if (this.hasWebVibrate && navigator.vibrate) {
+      navigator.vibrate(this.PATTERNS.LIGHT);
     }
   },
 
   async medium() {
-    if (await this.isAvailable()) {
+    if (!this.isEnabled) return;
+
+    if (this.hasNativeHaptics && window.Capacitor.Plugins.Haptics) {
       await window.Capacitor.Plugins.Haptics.impact({ style: 'MEDIUM' }).catch(() => {});
+    } else if (this.hasWebVibrate && navigator.vibrate) {
+      navigator.vibrate(this.PATTERNS.MEDIUM);
+    }
+  },
+
+  async heavy() {
+    if (!this.isEnabled) return;
+
+    if (this.hasNativeHaptics && window.Capacitor.Plugins.Haptics) {
+      await window.Capacitor.Plugins.Haptics.impact({ style: 'HEAVY' }).catch(() => {});
+    } else if (this.hasWebVibrate && navigator.vibrate) {
+      navigator.vibrate(this.PATTERNS.HEAVY);
     }
   }
 };


### PR DESCRIPTION
Hey! This PR implements haptic feedback for better mobile UX (#9).

**What's Added:**
- Enhanced HapticsService with Web Vibration API fallback
- Haptic feedback on:
  - Button presses and toggles
  - Form submissions  
  - Calendar day selection
  - Theme/language switches
  - Number input changes

**How it works:**
- Uses Capacitor Haptics plugin when available (native)
- Falls back to Web Vibration API for PWA/browser
- Different patterns for different actions

Tested on mobile and browser. Let me know what you think!

Closes #9