### PR TITLE
feat: Responsive Plan Selector + Uthmani Mushaf Reader

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.monthlyquran.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10502
-        versionName "1.5.2"
+        versionCode 10507
+        versionName "1.5.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.monthlyquran.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10507
-        versionName "1.5.7"
+        versionCode 10605
+        versionName "1.6.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "Monthly Quran",
-  "version": "1.5.7",
+  "version": "1.6.5",
   "description": "__MSG_extensionDescription__",
   "action": {
     "default_popup": "src/popup/popup.html",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "Monthly Quran",
-  "version": "1.5.2",
+  "version": "1.5.7",
   "description": "__MSG_extensionDescription__",
   "action": {
     "default_popup": "src/popup/popup.html",

--- a/chrome/src/core/css/components.css
+++ b/chrome/src/core/css/components.css
@@ -795,8 +795,8 @@
   flex-direction: row-reverse;
 }
 
-/* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
-.toggle-options {
+/* Responsive grid for unit-type plan selector (5 buttons) — only for setup-unit-type, not language/theme */
+.toggle-options:not(#setup-language-toggle):not(#setup-theme-toggle):not(#settings-language-toggle):not(#settings-theme-toggle):not(#settings-haptics-toggle) {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
 }
@@ -805,6 +805,15 @@
 .toggle-options button[data-value="juz"] {
   grid-column: 1 / -1;
   width: 100%;
+}
+
+/* Force flex layout for language and theme switches only */
+#setup-language-toggle,
+#setup-theme-toggle,
+#settings-language-toggle,
+#settings-theme-toggle,
+#settings-haptics-toggle {
+  display: flex;
 }
 
 /* Quick Stats */

--- a/chrome/src/core/css/components.css
+++ b/chrome/src/core/css/components.css
@@ -798,7 +798,7 @@
 /* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
 .toggle-options {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
 }
 
 /* Juz button spans full width when it wraps to its own row */

--- a/chrome/src/core/css/components.css
+++ b/chrome/src/core/css/components.css
@@ -795,6 +795,18 @@
   flex-direction: row-reverse;
 }
 
+/* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
+.toggle-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+}
+
+/* Juz button spans full width when it wraps to its own row */
+.toggle-options button[data-value="juz"] {
+  grid-column: 1 / -1;
+  width: 100%;
+}
+
 /* Quick Stats */
 .quick-stats {
   background-color: var(--card-bg);

--- a/chrome/src/core/js/components.js
+++ b/chrome/src/core/js/components.js
@@ -659,15 +659,14 @@ const UIComponents = {
 
     // Content area
     const content = document.createElement('div');
-    content.className = 'reading-content';
+    content.className = 'reading-content mushaf-page';
     content.style.cssText = `
       flex: 1;
       overflow-y: auto;
-      padding: 1.5rem;
-      direction: rtl; /* Quran text is always RTL */
-      line-height: 2.2;
-      font-size: 1.35rem;
-      font-family: 'Amiri', serif;
+      overflow-x: hidden;
+      padding: 1.5rem 1.25rem 1rem;
+      direction: rtl;
+      background-color: var(--bg);
       color: var(--fg);
     `;
 
@@ -743,51 +742,115 @@ const UIComponents = {
       if (textData && textData.data && textData.data.ayahs) {
         content.replaceChildren();
 
-        // Group by surah for better display
+        // Helper: Western digits → Arabic-Indic numerals
+        const toArabicNumerals = (n) =>
+          String(n).replace(/\d/g, d => '٠١٢٣٤٥٦٧٨٩'[d]);
+
+        // Mushaf page wrapper
+        const pageWrap = document.createElement('div');
+        pageWrap.style.cssText = `
+          font-family: 'Amiri Quran', 'Amiri', 'Scheherazade New', serif;
+          font-size: 1.25rem;
+          line-height: 2.2;
+          text-align: justify;
+          color: var(--fg);
+          overflow-wrap: break-word;
+          word-break: break-word;
+        `;
+
         let currentSurah = null;
+        let currentBlock = null;
+
+        const flushBlock = () => {
+          if (currentBlock) { pageWrap.appendChild(currentBlock); currentBlock = null; }
+        };
 
         textData.data.ayahs.forEach(ayah => {
+          // New surah
           if (currentSurah !== ayah.surah.number) {
+            flushBlock();
             currentSurah = ayah.surah.number;
-            const surahTitle = document.createElement('div');
-            surahTitle.style.cssText = `
+
+            // Surah name banner
+            const surahBanner = document.createElement('div');
+            surahBanner.style.cssText = `
               text-align: center;
-              background-color: var(--muted-bg);
-              padding: 0.5rem;
-              margin: 1.5rem 0 1rem 0;
-              border-radius: var(--radius);
-              font-size: 1.1rem;
-              color: var(--primary-bg);
+              margin: 1.25rem 0 0.75rem;
+              padding: 0.5rem 1rem;
+              border-top: 1px solid var(--border-color);
+              border-bottom: 1px solid var(--border-color);
+              font-family: 'Amiri Quran', 'Amiri', serif;
+              font-size: 1.3rem;
               font-weight: bold;
+              color: var(--fg);
             `;
-            surahTitle.textContent = `${ayah.surah.name}`;
-            content.appendChild(surahTitle);
+            surahBanner.textContent = ayah.surah.name;
+            pageWrap.appendChild(surahBanner);
+
+            // Bismillah — skip At-Tawbah (9) and Al-Fatiha first ayah (included in text)
+            if (ayah.surah.number !== 9 && !(ayah.surah.number === 1 && ayah.numberInSurah === 1)) {
+              const bismillah = document.createElement('div');
+              bismillah.style.cssText = `
+                text-align: center;
+                font-family: 'Amiri Quran', 'Amiri', serif;
+                font-size: 1.3rem;
+                margin-bottom: 0.75rem;
+                color: var(--fg);
+              `;
+              bismillah.textContent = '\u0628\u0650\u0633\u0652\u0645\u0650 \u0671\u0644\u0644\u0651\u064E\u0647\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0652\u0645\u064E\u0640\u0670\u0646\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0650\u06CC\u0645\u0650';
+              pageWrap.appendChild(bismillah);
+            }
+
+            currentBlock = document.createElement('div');
+            currentBlock.style.cssText = 'text-align: justify; text-align-last: center;';
           }
 
-          const ayahSpan = document.createElement('span');
-          ayahSpan.className = 'ayah-text';
-          ayahSpan.textContent = ayah.text + ' ';
+          // Ayah text
+          currentBlock.appendChild(document.createTextNode(ayah.text + ' '));
 
-          const badge = document.createElement('span');
-          badge.style.cssText = `
+          // Ayah end marker: green circle with number (like Uthmani mushaf)
+          const marker = document.createElement('span');
+          marker.style.cssText = `
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            width: 1.8rem;
-            height: 1.8rem;
-            border: 1px solid var(--border-color);
+            width: 1.6rem;
+            height: 1.6rem;
             border-radius: 50%;
-            font-size: 0.75rem;
-            margin: 0 0.5rem;
-            color: var(--muted-fg);
+            border: 1.5px solid var(--success-bg);
+            font-family: sans-serif;
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: var(--success-bg);
             vertical-align: middle;
+            margin: 0 0.15em;
+            white-space: nowrap;
           `;
-          badge.textContent = ayah.numberInSurah;
-
-          ayahSpan.appendChild(badge);
-          content.appendChild(ayahSpan);
+          marker.textContent = toArabicNumerals(ayah.numberInSurah);
+          currentBlock.appendChild(marker);
+          currentBlock.appendChild(document.createTextNode(' '));
         });
 
+        flushBlock();
+
+        // Page number footer
+        const pageFooter = document.createElement('div');
+        pageFooter.style.cssText = `
+          text-align: center;
+          margin-top: 1.5rem;
+          padding-top: 0.5rem;
+          border-top: 1px solid var(--border-color);
+          font-family: 'Amiri Quran', 'Amiri', serif;
+          font-size: 0.95rem;
+          color: var(--muted-fg);
+        `;
+        const displayPage = unitSize && parseFloat(unitSize) > 1
+          ? toArabicNumerals(unitNumber) + ' \u2013 ' + toArabicNumerals(Math.floor(unitNumber + parseFloat(unitSize) - 1))
+          : toArabicNumerals(unitNumber);
+        pageFooter.textContent = displayPage;
+        pageWrap.appendChild(pageFooter);
+
+        content.appendChild(pageWrap);
         modal.appendChild(footer);
       } else {
         content.textContent = i18n.t('reading.error');

--- a/chrome/src/core/js/env.js
+++ b/chrome/src/core/js/env.js
@@ -2,5 +2,5 @@ window.env = {
     isExtension: typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id,
     isMobile: !!(window.Capacitor && window.Capacitor.isNative),
     isWeb: !(typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id) && !(window.Capacitor && window.Capacitor.isNative),
-    version: '1.5.2'
+    version: '1.5.7'
 };

--- a/chrome/src/core/js/env.js
+++ b/chrome/src/core/js/env.js
@@ -2,5 +2,5 @@ window.env = {
     isExtension: typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id,
     isMobile: !!(window.Capacitor && window.Capacitor.isNative),
     isWeb: !(typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id) && !(window.Capacitor && window.Capacitor.isNative),
-    version: '1.5.7'
+    version: '1.6.5'
 };

--- a/core/css/components.css
+++ b/core/css/components.css
@@ -795,8 +795,8 @@
   flex-direction: row-reverse;
 }
 
-/* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
-.toggle-options {
+/* Responsive grid for unit-type plan selector (5 buttons) — only for setup-unit-type, not language/theme */
+.toggle-options:not(#setup-language-toggle):not(#setup-theme-toggle):not(#settings-language-toggle):not(#settings-theme-toggle):not(#settings-haptics-toggle) {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
 }
@@ -805,6 +805,15 @@
 .toggle-options button[data-value="juz"] {
   grid-column: 1 / -1;
   width: 100%;
+}
+
+/* Force flex layout for language and theme switches only */
+#setup-language-toggle,
+#setup-theme-toggle,
+#settings-language-toggle,
+#settings-theme-toggle,
+#settings-haptics-toggle {
+  display: flex;
 }
 
 /* Quick Stats */

--- a/core/css/components.css
+++ b/core/css/components.css
@@ -798,7 +798,7 @@
 /* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
 .toggle-options {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
 }
 
 /* Juz button spans full width when it wraps to its own row */

--- a/core/css/components.css
+++ b/core/css/components.css
@@ -795,6 +795,18 @@
   flex-direction: row-reverse;
 }
 
+/* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
+.toggle-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+}
+
+/* Juz button spans full width when it wraps to its own row */
+.toggle-options button[data-value="juz"] {
+  grid-column: 1 / -1;
+  width: 100%;
+}
+
 /* Quick Stats */
 .quick-stats {
   background-color: var(--card-bg);

--- a/core/js/components.js
+++ b/core/js/components.js
@@ -659,15 +659,14 @@ const UIComponents = {
 
     // Content area
     const content = document.createElement('div');
-    content.className = 'reading-content';
+    content.className = 'reading-content mushaf-page';
     content.style.cssText = `
       flex: 1;
       overflow-y: auto;
-      padding: 1.5rem;
-      direction: rtl; /* Quran text is always RTL */
-      line-height: 2.2;
-      font-size: 1.35rem;
-      font-family: 'Amiri', serif;
+      overflow-x: hidden;
+      padding: 1.5rem 1.25rem 1rem;
+      direction: rtl;
+      background-color: var(--bg);
       color: var(--fg);
     `;
 
@@ -743,51 +742,115 @@ const UIComponents = {
       if (textData && textData.data && textData.data.ayahs) {
         content.replaceChildren();
 
-        // Group by surah for better display
+        // Helper: Western digits → Arabic-Indic numerals
+        const toArabicNumerals = (n) =>
+          String(n).replace(/\d/g, d => '٠١٢٣٤٥٦٧٨٩'[d]);
+
+        // Mushaf page wrapper
+        const pageWrap = document.createElement('div');
+        pageWrap.style.cssText = `
+          font-family: 'Amiri Quran', 'Amiri', 'Scheherazade New', serif;
+          font-size: 1.25rem;
+          line-height: 2.2;
+          text-align: justify;
+          color: var(--fg);
+          overflow-wrap: break-word;
+          word-break: break-word;
+        `;
+
         let currentSurah = null;
+        let currentBlock = null;
+
+        const flushBlock = () => {
+          if (currentBlock) { pageWrap.appendChild(currentBlock); currentBlock = null; }
+        };
 
         textData.data.ayahs.forEach(ayah => {
+          // New surah
           if (currentSurah !== ayah.surah.number) {
+            flushBlock();
             currentSurah = ayah.surah.number;
-            const surahTitle = document.createElement('div');
-            surahTitle.style.cssText = `
+
+            // Surah name banner
+            const surahBanner = document.createElement('div');
+            surahBanner.style.cssText = `
               text-align: center;
-              background-color: var(--muted-bg);
-              padding: 0.5rem;
-              margin: 1.5rem 0 1rem 0;
-              border-radius: var(--radius);
-              font-size: 1.1rem;
-              color: var(--primary-bg);
+              margin: 1.25rem 0 0.75rem;
+              padding: 0.5rem 1rem;
+              border-top: 1px solid var(--border-color);
+              border-bottom: 1px solid var(--border-color);
+              font-family: 'Amiri Quran', 'Amiri', serif;
+              font-size: 1.3rem;
               font-weight: bold;
+              color: var(--fg);
             `;
-            surahTitle.textContent = `${ayah.surah.name}`;
-            content.appendChild(surahTitle);
+            surahBanner.textContent = ayah.surah.name;
+            pageWrap.appendChild(surahBanner);
+
+            // Bismillah — skip At-Tawbah (9) and Al-Fatiha first ayah (included in text)
+            if (ayah.surah.number !== 9 && !(ayah.surah.number === 1 && ayah.numberInSurah === 1)) {
+              const bismillah = document.createElement('div');
+              bismillah.style.cssText = `
+                text-align: center;
+                font-family: 'Amiri Quran', 'Amiri', serif;
+                font-size: 1.3rem;
+                margin-bottom: 0.75rem;
+                color: var(--fg);
+              `;
+              bismillah.textContent = '\u0628\u0650\u0633\u0652\u0645\u0650 \u0671\u0644\u0644\u0651\u064E\u0647\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0652\u0645\u064E\u0640\u0670\u0646\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0650\u06CC\u0645\u0650';
+              pageWrap.appendChild(bismillah);
+            }
+
+            currentBlock = document.createElement('div');
+            currentBlock.style.cssText = 'text-align: justify; text-align-last: center;';
           }
 
-          const ayahSpan = document.createElement('span');
-          ayahSpan.className = 'ayah-text';
-          ayahSpan.textContent = ayah.text + ' ';
+          // Ayah text
+          currentBlock.appendChild(document.createTextNode(ayah.text + ' '));
 
-          const badge = document.createElement('span');
-          badge.style.cssText = `
+          // Ayah end marker: green circle with number (like Uthmani mushaf)
+          const marker = document.createElement('span');
+          marker.style.cssText = `
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            width: 1.8rem;
-            height: 1.8rem;
-            border: 1px solid var(--border-color);
+            width: 1.6rem;
+            height: 1.6rem;
             border-radius: 50%;
-            font-size: 0.75rem;
-            margin: 0 0.5rem;
-            color: var(--muted-fg);
+            border: 1.5px solid var(--success-bg);
+            font-family: sans-serif;
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: var(--success-bg);
             vertical-align: middle;
+            margin: 0 0.15em;
+            white-space: nowrap;
           `;
-          badge.textContent = ayah.numberInSurah;
-
-          ayahSpan.appendChild(badge);
-          content.appendChild(ayahSpan);
+          marker.textContent = toArabicNumerals(ayah.numberInSurah);
+          currentBlock.appendChild(marker);
+          currentBlock.appendChild(document.createTextNode(' '));
         });
 
+        flushBlock();
+
+        // Page number footer
+        const pageFooter = document.createElement('div');
+        pageFooter.style.cssText = `
+          text-align: center;
+          margin-top: 1.5rem;
+          padding-top: 0.5rem;
+          border-top: 1px solid var(--border-color);
+          font-family: 'Amiri Quran', 'Amiri', serif;
+          font-size: 0.95rem;
+          color: var(--muted-fg);
+        `;
+        const displayPage = unitSize && parseFloat(unitSize) > 1
+          ? toArabicNumerals(unitNumber) + ' \u2013 ' + toArabicNumerals(Math.floor(unitNumber + parseFloat(unitSize) - 1))
+          : toArabicNumerals(unitNumber);
+        pageFooter.textContent = displayPage;
+        pageWrap.appendChild(pageFooter);
+
+        content.appendChild(pageWrap);
         modal.appendChild(footer);
       } else {
         content.textContent = i18n.t('reading.error');

--- a/core/js/env.js
+++ b/core/js/env.js
@@ -2,5 +2,5 @@ window.env = {
     isExtension: typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id,
     isMobile: !!(window.Capacitor && window.Capacitor.isNative),
     isWeb: !(typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id) && !(window.Capacitor && window.Capacitor.isNative),
-    version: '1.5.2'
+    version: '1.5.7'
 };

--- a/core/js/env.js
+++ b/core/js/env.js
@@ -2,5 +2,5 @@ window.env = {
     isExtension: typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id,
     isMobile: !!(window.Capacitor && window.Capacitor.isNative),
     isWeb: !(typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id) && !(window.Capacitor && window.Capacitor.isNative),
-    version: '1.5.7'
+    version: '1.6.5'
 };

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "short_name": "Monthly Quran",
-  "version": "1.5.2",
+  "version": "1.5.7",
   "description": "__MSG_extensionDescription__",
   "browser_specific_settings": {
     "gecko": {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "short_name": "Monthly Quran",
-  "version": "1.5.7",
+  "version": "1.6.5",
   "description": "__MSG_extensionDescription__",
   "browser_specific_settings": {
     "gecko": {

--- a/firefox/src/core/css/components.css
+++ b/firefox/src/core/css/components.css
@@ -795,8 +795,8 @@
   flex-direction: row-reverse;
 }
 
-/* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
-.toggle-options {
+/* Responsive grid for unit-type plan selector (5 buttons) — only for setup-unit-type, not language/theme */
+.toggle-options:not(#setup-language-toggle):not(#setup-theme-toggle):not(#settings-language-toggle):not(#settings-theme-toggle):not(#settings-haptics-toggle) {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
 }
@@ -805,6 +805,15 @@
 .toggle-options button[data-value="juz"] {
   grid-column: 1 / -1;
   width: 100%;
+}
+
+/* Force flex layout for language and theme switches only */
+#setup-language-toggle,
+#setup-theme-toggle,
+#settings-language-toggle,
+#settings-theme-toggle,
+#settings-haptics-toggle {
+  display: flex;
 }
 
 /* Quick Stats */

--- a/firefox/src/core/css/components.css
+++ b/firefox/src/core/css/components.css
@@ -798,7 +798,7 @@
 /* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
 .toggle-options {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
 }
 
 /* Juz button spans full width when it wraps to its own row */

--- a/firefox/src/core/css/components.css
+++ b/firefox/src/core/css/components.css
@@ -795,6 +795,18 @@
   flex-direction: row-reverse;
 }
 
+/* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
+.toggle-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+}
+
+/* Juz button spans full width when it wraps to its own row */
+.toggle-options button[data-value="juz"] {
+  grid-column: 1 / -1;
+  width: 100%;
+}
+
 /* Quick Stats */
 .quick-stats {
   background-color: var(--card-bg);

--- a/firefox/src/core/js/components.js
+++ b/firefox/src/core/js/components.js
@@ -659,15 +659,14 @@ const UIComponents = {
 
     // Content area
     const content = document.createElement('div');
-    content.className = 'reading-content';
+    content.className = 'reading-content mushaf-page';
     content.style.cssText = `
       flex: 1;
       overflow-y: auto;
-      padding: 1.5rem;
-      direction: rtl; /* Quran text is always RTL */
-      line-height: 2.2;
-      font-size: 1.35rem;
-      font-family: 'Amiri', serif;
+      overflow-x: hidden;
+      padding: 1.5rem 1.25rem 1rem;
+      direction: rtl;
+      background-color: var(--bg);
       color: var(--fg);
     `;
 
@@ -743,51 +742,115 @@ const UIComponents = {
       if (textData && textData.data && textData.data.ayahs) {
         content.replaceChildren();
 
-        // Group by surah for better display
+        // Helper: Western digits → Arabic-Indic numerals
+        const toArabicNumerals = (n) =>
+          String(n).replace(/\d/g, d => '٠١٢٣٤٥٦٧٨٩'[d]);
+
+        // Mushaf page wrapper
+        const pageWrap = document.createElement('div');
+        pageWrap.style.cssText = `
+          font-family: 'Amiri Quran', 'Amiri', 'Scheherazade New', serif;
+          font-size: 1.25rem;
+          line-height: 2.2;
+          text-align: justify;
+          color: var(--fg);
+          overflow-wrap: break-word;
+          word-break: break-word;
+        `;
+
         let currentSurah = null;
+        let currentBlock = null;
+
+        const flushBlock = () => {
+          if (currentBlock) { pageWrap.appendChild(currentBlock); currentBlock = null; }
+        };
 
         textData.data.ayahs.forEach(ayah => {
+          // New surah
           if (currentSurah !== ayah.surah.number) {
+            flushBlock();
             currentSurah = ayah.surah.number;
-            const surahTitle = document.createElement('div');
-            surahTitle.style.cssText = `
+
+            // Surah name banner
+            const surahBanner = document.createElement('div');
+            surahBanner.style.cssText = `
               text-align: center;
-              background-color: var(--muted-bg);
-              padding: 0.5rem;
-              margin: 1.5rem 0 1rem 0;
-              border-radius: var(--radius);
-              font-size: 1.1rem;
-              color: var(--primary-bg);
+              margin: 1.25rem 0 0.75rem;
+              padding: 0.5rem 1rem;
+              border-top: 1px solid var(--border-color);
+              border-bottom: 1px solid var(--border-color);
+              font-family: 'Amiri Quran', 'Amiri', serif;
+              font-size: 1.3rem;
               font-weight: bold;
+              color: var(--fg);
             `;
-            surahTitle.textContent = `${ayah.surah.name}`;
-            content.appendChild(surahTitle);
+            surahBanner.textContent = ayah.surah.name;
+            pageWrap.appendChild(surahBanner);
+
+            // Bismillah — skip At-Tawbah (9) and Al-Fatiha first ayah (included in text)
+            if (ayah.surah.number !== 9 && !(ayah.surah.number === 1 && ayah.numberInSurah === 1)) {
+              const bismillah = document.createElement('div');
+              bismillah.style.cssText = `
+                text-align: center;
+                font-family: 'Amiri Quran', 'Amiri', serif;
+                font-size: 1.3rem;
+                margin-bottom: 0.75rem;
+                color: var(--fg);
+              `;
+              bismillah.textContent = '\u0628\u0650\u0633\u0652\u0645\u0650 \u0671\u0644\u0644\u0651\u064E\u0647\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0652\u0645\u064E\u0640\u0670\u0646\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0650\u06CC\u0645\u0650';
+              pageWrap.appendChild(bismillah);
+            }
+
+            currentBlock = document.createElement('div');
+            currentBlock.style.cssText = 'text-align: justify; text-align-last: center;';
           }
 
-          const ayahSpan = document.createElement('span');
-          ayahSpan.className = 'ayah-text';
-          ayahSpan.textContent = ayah.text + ' ';
+          // Ayah text
+          currentBlock.appendChild(document.createTextNode(ayah.text + ' '));
 
-          const badge = document.createElement('span');
-          badge.style.cssText = `
+          // Ayah end marker: green circle with number (like Uthmani mushaf)
+          const marker = document.createElement('span');
+          marker.style.cssText = `
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            width: 1.8rem;
-            height: 1.8rem;
-            border: 1px solid var(--border-color);
+            width: 1.6rem;
+            height: 1.6rem;
             border-radius: 50%;
-            font-size: 0.75rem;
-            margin: 0 0.5rem;
-            color: var(--muted-fg);
+            border: 1.5px solid var(--success-bg);
+            font-family: sans-serif;
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: var(--success-bg);
             vertical-align: middle;
+            margin: 0 0.15em;
+            white-space: nowrap;
           `;
-          badge.textContent = ayah.numberInSurah;
-
-          ayahSpan.appendChild(badge);
-          content.appendChild(ayahSpan);
+          marker.textContent = toArabicNumerals(ayah.numberInSurah);
+          currentBlock.appendChild(marker);
+          currentBlock.appendChild(document.createTextNode(' '));
         });
 
+        flushBlock();
+
+        // Page number footer
+        const pageFooter = document.createElement('div');
+        pageFooter.style.cssText = `
+          text-align: center;
+          margin-top: 1.5rem;
+          padding-top: 0.5rem;
+          border-top: 1px solid var(--border-color);
+          font-family: 'Amiri Quran', 'Amiri', serif;
+          font-size: 0.95rem;
+          color: var(--muted-fg);
+        `;
+        const displayPage = unitSize && parseFloat(unitSize) > 1
+          ? toArabicNumerals(unitNumber) + ' \u2013 ' + toArabicNumerals(Math.floor(unitNumber + parseFloat(unitSize) - 1))
+          : toArabicNumerals(unitNumber);
+        pageFooter.textContent = displayPage;
+        pageWrap.appendChild(pageFooter);
+
+        content.appendChild(pageWrap);
         modal.appendChild(footer);
       } else {
         content.textContent = i18n.t('reading.error');

--- a/firefox/src/core/js/env.js
+++ b/firefox/src/core/js/env.js
@@ -2,5 +2,5 @@ window.env = {
     isExtension: typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id,
     isMobile: !!(window.Capacitor && window.Capacitor.isNative),
     isWeb: !(typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id) && !(window.Capacitor && window.Capacitor.isNative),
-    version: '1.5.2'
+    version: '1.5.7'
 };

--- a/firefox/src/core/js/env.js
+++ b/firefox/src/core/js/env.js
@@ -2,5 +2,5 @@ window.env = {
     isExtension: typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id,
     isMobile: !!(window.Capacitor && window.Capacitor.isNative),
     isWeb: !(typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id) && !(window.Capacitor && window.Capacitor.isNative),
-    version: '1.5.7'
+    version: '1.6.5'
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monthlyquran",
-  "version": "1.5.2",
+  "version": "1.6.3",
   "description": "A simple web application for tracking Quran memorization using a spaced repetition system. The app helps you follow a 7-station review schedule based on memory retention principles.",
   "main": "sw.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monthlyquran",
-  "version": "1.6.3",
+  "version": "1.6.5",
   "description": "A simple web application for tracking Quran memorization using a spaced repetition system. The app helps you follow a 7-station review schedule based on memory retention principles.",
   "main": "sw.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sync": "node scripts/sync.js && node scripts/patch-android-plugins.js",
     "build": "node scripts/build.js",
     "build:extensions": "node scripts/build-extensions.js",
-    "android:run": "npm run sync && ANDROID_HOME=/home/hadi/Android/Sdk npx cap run android",
+    "android:run": "npm run sync && ANDROID_HOME=/home/$USER/Android/Sdk npx cap run android",
     "android:build": "cd android && ./gradlew assembleDebug",
     "android:build:release": "cd android && ./gradlew bundleRelease",
     "sign:android": "bash scripts/sign-release-bundle.sh",

--- a/www/core/css/components.css
+++ b/www/core/css/components.css
@@ -795,8 +795,8 @@
   flex-direction: row-reverse;
 }
 
-/* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
-.toggle-options {
+/* Responsive grid for unit-type plan selector (5 buttons) — only for setup-unit-type, not language/theme */
+.toggle-options:not(#setup-language-toggle):not(#setup-theme-toggle):not(#settings-language-toggle):not(#settings-theme-toggle):not(#settings-haptics-toggle) {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
 }
@@ -805,6 +805,15 @@
 .toggle-options button[data-value="juz"] {
   grid-column: 1 / -1;
   width: 100%;
+}
+
+/* Force flex layout for language and theme switches only */
+#setup-language-toggle,
+#setup-theme-toggle,
+#settings-language-toggle,
+#settings-theme-toggle,
+#settings-haptics-toggle {
+  display: flex;
 }
 
 /* Quick Stats */

--- a/www/core/css/components.css
+++ b/www/core/css/components.css
@@ -798,7 +798,7 @@
 /* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
 .toggle-options {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
 }
 
 /* Juz button spans full width when it wraps to its own row */

--- a/www/core/css/components.css
+++ b/www/core/css/components.css
@@ -795,6 +795,18 @@
   flex-direction: row-reverse;
 }
 
+/* Responsive grid for unit-type plan selector (5 buttons) — applies to all toggle-options */
+.toggle-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+}
+
+/* Juz button spans full width when it wraps to its own row */
+.toggle-options button[data-value="juz"] {
+  grid-column: 1 / -1;
+  width: 100%;
+}
+
 /* Quick Stats */
 .quick-stats {
   background-color: var(--card-bg);

--- a/www/core/js/components.js
+++ b/www/core/js/components.js
@@ -659,15 +659,14 @@ const UIComponents = {
 
     // Content area
     const content = document.createElement('div');
-    content.className = 'reading-content';
+    content.className = 'reading-content mushaf-page';
     content.style.cssText = `
       flex: 1;
       overflow-y: auto;
-      padding: 1.5rem;
-      direction: rtl; /* Quran text is always RTL */
-      line-height: 2.2;
-      font-size: 1.35rem;
-      font-family: 'Amiri', serif;
+      overflow-x: hidden;
+      padding: 1.5rem 1.25rem 1rem;
+      direction: rtl;
+      background-color: var(--bg);
       color: var(--fg);
     `;
 
@@ -743,51 +742,115 @@ const UIComponents = {
       if (textData && textData.data && textData.data.ayahs) {
         content.replaceChildren();
 
-        // Group by surah for better display
+        // Helper: Western digits → Arabic-Indic numerals
+        const toArabicNumerals = (n) =>
+          String(n).replace(/\d/g, d => '٠١٢٣٤٥٦٧٨٩'[d]);
+
+        // Mushaf page wrapper
+        const pageWrap = document.createElement('div');
+        pageWrap.style.cssText = `
+          font-family: 'Amiri Quran', 'Amiri', 'Scheherazade New', serif;
+          font-size: 1.25rem;
+          line-height: 2.2;
+          text-align: justify;
+          color: var(--fg);
+          overflow-wrap: break-word;
+          word-break: break-word;
+        `;
+
         let currentSurah = null;
+        let currentBlock = null;
+
+        const flushBlock = () => {
+          if (currentBlock) { pageWrap.appendChild(currentBlock); currentBlock = null; }
+        };
 
         textData.data.ayahs.forEach(ayah => {
+          // New surah
           if (currentSurah !== ayah.surah.number) {
+            flushBlock();
             currentSurah = ayah.surah.number;
-            const surahTitle = document.createElement('div');
-            surahTitle.style.cssText = `
+
+            // Surah name banner
+            const surahBanner = document.createElement('div');
+            surahBanner.style.cssText = `
               text-align: center;
-              background-color: var(--muted-bg);
-              padding: 0.5rem;
-              margin: 1.5rem 0 1rem 0;
-              border-radius: var(--radius);
-              font-size: 1.1rem;
-              color: var(--primary-bg);
+              margin: 1.25rem 0 0.75rem;
+              padding: 0.5rem 1rem;
+              border-top: 1px solid var(--border-color);
+              border-bottom: 1px solid var(--border-color);
+              font-family: 'Amiri Quran', 'Amiri', serif;
+              font-size: 1.3rem;
               font-weight: bold;
+              color: var(--fg);
             `;
-            surahTitle.textContent = `${ayah.surah.name}`;
-            content.appendChild(surahTitle);
+            surahBanner.textContent = ayah.surah.name;
+            pageWrap.appendChild(surahBanner);
+
+            // Bismillah — skip At-Tawbah (9) and Al-Fatiha first ayah (included in text)
+            if (ayah.surah.number !== 9 && !(ayah.surah.number === 1 && ayah.numberInSurah === 1)) {
+              const bismillah = document.createElement('div');
+              bismillah.style.cssText = `
+                text-align: center;
+                font-family: 'Amiri Quran', 'Amiri', serif;
+                font-size: 1.3rem;
+                margin-bottom: 0.75rem;
+                color: var(--fg);
+              `;
+              bismillah.textContent = '\u0628\u0650\u0633\u0652\u0645\u0650 \u0671\u0644\u0644\u0651\u064E\u0647\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0652\u0645\u064E\u0640\u0670\u0646\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0650\u06CC\u0645\u0650';
+              pageWrap.appendChild(bismillah);
+            }
+
+            currentBlock = document.createElement('div');
+            currentBlock.style.cssText = 'text-align: justify; text-align-last: center;';
           }
 
-          const ayahSpan = document.createElement('span');
-          ayahSpan.className = 'ayah-text';
-          ayahSpan.textContent = ayah.text + ' ';
+          // Ayah text
+          currentBlock.appendChild(document.createTextNode(ayah.text + ' '));
 
-          const badge = document.createElement('span');
-          badge.style.cssText = `
+          // Ayah end marker: green circle with number (like Uthmani mushaf)
+          const marker = document.createElement('span');
+          marker.style.cssText = `
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            width: 1.8rem;
-            height: 1.8rem;
-            border: 1px solid var(--border-color);
+            width: 1.6rem;
+            height: 1.6rem;
             border-radius: 50%;
-            font-size: 0.75rem;
-            margin: 0 0.5rem;
-            color: var(--muted-fg);
+            border: 1.5px solid var(--success-bg);
+            font-family: sans-serif;
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: var(--success-bg);
             vertical-align: middle;
+            margin: 0 0.15em;
+            white-space: nowrap;
           `;
-          badge.textContent = ayah.numberInSurah;
-
-          ayahSpan.appendChild(badge);
-          content.appendChild(ayahSpan);
+          marker.textContent = toArabicNumerals(ayah.numberInSurah);
+          currentBlock.appendChild(marker);
+          currentBlock.appendChild(document.createTextNode(' '));
         });
 
+        flushBlock();
+
+        // Page number footer
+        const pageFooter = document.createElement('div');
+        pageFooter.style.cssText = `
+          text-align: center;
+          margin-top: 1.5rem;
+          padding-top: 0.5rem;
+          border-top: 1px solid var(--border-color);
+          font-family: 'Amiri Quran', 'Amiri', serif;
+          font-size: 0.95rem;
+          color: var(--muted-fg);
+        `;
+        const displayPage = unitSize && parseFloat(unitSize) > 1
+          ? toArabicNumerals(unitNumber) + ' \u2013 ' + toArabicNumerals(Math.floor(unitNumber + parseFloat(unitSize) - 1))
+          : toArabicNumerals(unitNumber);
+        pageFooter.textContent = displayPage;
+        pageWrap.appendChild(pageFooter);
+
+        content.appendChild(pageWrap);
         modal.appendChild(footer);
       } else {
         content.textContent = i18n.t('reading.error');

--- a/www/core/js/env.js
+++ b/www/core/js/env.js
@@ -2,5 +2,5 @@ window.env = {
     isExtension: typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id,
     isMobile: !!(window.Capacitor && window.Capacitor.isNative),
     isWeb: !(typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id) && !(window.Capacitor && window.Capacitor.isNative),
-    version: '1.5.2'
+    version: '1.5.7'
 };

--- a/www/core/js/env.js
+++ b/www/core/js/env.js
@@ -2,5 +2,5 @@ window.env = {
     isExtension: typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id,
     isMobile: !!(window.Capacitor && window.Capacitor.isNative),
     isWeb: !(typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id) && !(window.Capacitor && window.Capacitor.isNative),
-    version: '1.5.7'
+    version: '1.6.5'
 };

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -58,5 +58,5 @@
       "purpose": "any maskable"
     }
   ],
-  "version": "1.5.7"
+  "version": "1.6.5"
 }

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -58,5 +58,5 @@
       "purpose": "any maskable"
     }
   ],
-  "version": "1.5.2"
+  "version": "1.5.7"
 }

--- a/www/sw.js
+++ b/www/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'monthlyquran-v1.5.7';
+const CACHE_NAME = 'monthlyquran-v1.6.5';
 const urlsToCache = [
   './',
   './index.html',

--- a/www/sw.js
+++ b/www/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'monthlyquran-v1.5.2';
+const CACHE_NAME = 'monthlyquran-v1.5.7';
 const urlsToCache = [
   './',
   './index.html',
@@ -27,6 +27,15 @@ const urlsToCache = [
   './manifest.json'
 ];
 
+// CSS files — always fetch fresh from network (never serve from cache)
+const CSS_FILES = [
+  './core/css/components.css',
+  './core/css/styles.css',
+  './core/css/themes.css',
+  './core/css/navigation.css',
+  './core/css/fonts.css',
+];
+
 // Install event - cache resources
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -53,20 +62,37 @@ self.addEventListener('activate', (event) => {
   return self.clients.claim();
 });
 
-// Fetch event - serve from cache, fallback to network
+// Fetch event
 self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  const isCSSFile = CSS_FILES.some(f => url.pathname.endsWith(f.replace('./', '/')));
+
+  if (isCSSFile) {
+    // Network-first for CSS: always get fresh styles, fall back to cache
+    event.respondWith(
+      fetch(event.request)
+        .then((networkResponse) => {
+          // Update cache with fresh version
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, networkResponse.clone()));
+          return networkResponse;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
+  // Cache-first for everything else
   event.respondWith(
     caches.match(event.request)
       .then((response) => {
-        // Return cached version or fetch from network
         return response || fetch(event.request);
       })
       .catch(() => {
-        // If both fail, return offline page for navigation requests
         if (event.request.mode === 'navigate') {
           return caches.match('./index.html');
         }
       })
   );
 });
+
 


### PR DESCRIPTION
Closes #21 
Closes #4 

## Changes

### 🎨 Responsive Plan Selector
- Made plan selector buttons (صفحة / آية / ربع / حزب / جزء) responsive using CSS Grid
- 4 buttons in first row, جزء spans full width on second row
- Applied to **all** toggle instances: setup wizard, add memorization dialog, and edit config dialog

### 📖 Uthmani Mushaf Reader
- Restyled the reading modal to match authentic mushaf layout
- Uses app's dark blue theme background (`var(--bg)`)
- Justified Arabic text with Amiri Quran font
- Green circle ayah markers with Arabic-Indic numerals (٦ ٧ ٨...)
- Surah name banners with borders
- Bismillah headers per surah (except Al-Fatiha & At-Tawbah)
- Page number footer with Arabic-Indic digits
- Fixed text overflow and word spacing issues

### 🔧 Service Worker
- Switched CSS files to **network-first** fetch strategy to prevent stale cached styles
- Version bump to v1.6.0